### PR TITLE
Opção de Layout Sem Sacador

### DIFF
--- a/Banco_Bansirul.cs
+++ b/Banco_Bansirul.cs
@@ -1,0 +1,986 @@
+using BoletoNet.EDI.Banco;
+using BoletoNet.Util;
+using System;
+using System.Web.UI;
+
+[assembly: WebResource("BoletoNet.Imagens.041.jpg", "image/jpg")]
+namespace BoletoNet
+{
+    /// <Author>
+    /// Felipe Silveira - Transis Software
+    /// </Author>
+    internal class Banco_Banrisul : AbstractBanco, IBanco
+    {
+        private string _dacNossoNumero = string.Empty;
+        private int _primDigito;
+        private int _segDigito;
+
+        /// <author>
+        /// Classe responsavel em criar os campos do Banco Banrisul.
+        /// </author>
+        internal Banco_Banrisul()
+        {
+            this.Codigo = 041;
+            this.Digito = "8";
+            this.Nome = "Banco Banrisul";
+        }
+
+        public override void ValidaBoleto(Boleto boleto)
+        {
+            boleto.ContaBancaria = boleto.Cedente.ContaBancaria;
+
+            //Formata o tamanho do número da agência
+            if (boleto.Cedente.ContaBancaria.Conta.Length < 4)
+                throw new Exception("Número da agência inválido");
+
+            //Formata o tamanho do número da conta corrente
+            if (boleto.Cedente.ContaBancaria.Conta.Length < 7)
+                boleto.Cedente.ContaBancaria.Conta = Utils.FormatCode(boleto.Cedente.ContaBancaria.Conta, 7);
+
+            //Formata o tamanho do número de nosso número
+            if (boleto.NossoNumero.Length < 8)
+                boleto.NossoNumero = Utils.FormatCode(boleto.NossoNumero, 8);
+            else if (boleto.NossoNumero.Length > 8)
+                throw new NotSupportedException("Para o banco Banrisul, o nosso número deve ter 08 posições e 02 dígitos verificadores (calculados automaticamente).");
+
+            boleto.NossoNumero = CalcularNCNossoNumero(boleto.NossoNumero);
+
+            //Atribui o nome do banco ao local de pagamento
+            if (boleto.LocalPagamento == "Até o vencimento, preferencialmente no ")
+                boleto.LocalPagamento += Nome;
+
+            //Verifica se data do processamento é valida
+            if (boleto.DataProcessamento == DateTime.MinValue) // diegomodolo (diego.ribeiro@nectarnet.com.br)
+                boleto.DataProcessamento = DateTime.Now;
+
+            //Verifica se data do documento é valida
+            if (boleto.DataDocumento == DateTime.MinValue) // diegomodolo (diego.ribeiro@nectarnet.com.br)
+                boleto.DataDocumento = DateTime.Now;
+
+            //Verifica se o codigo do cedente é valido
+            if (boleto.Cedente.DigitoCedente.Equals(-1))
+            {
+                var codCedente = boleto.Cedente.Codigo.Replace(".", "").Replace("-", "");
+                boleto.Cedente.DigCedente = codCedente.Substring((codCedente.Length - 2), 2);
+                boleto.Cedente.DigitoCedente = Convert.ToInt32(codCedente.Substring((codCedente.Length - 2), 2));
+            }
+
+            FormataCodigoBarra(boleto);
+            FormataLinhaDigitavel(boleto);
+            FormataNossoNumero(boleto);
+            FormataCodigoCedente(boleto);
+        }
+
+        private static void FormataCodigoCedente(Boleto boleto)
+        {
+            if (!boleto.Cedente.Codigo.Substring(0, 4).Equals(boleto.ContaBancaria.Agencia))
+                boleto.Cedente.Codigo = boleto.ContaBancaria.Agencia + boleto.Cedente.Codigo.Replace(".", "").Replace("-", "");
+        }
+
+        private string CalcularNCNossoNumero(string nossoNumero)
+        {
+            int dv1 = Mod10Banri(nossoNumero);
+            int dv1e2 = Mod11Banri(nossoNumero, dv1); // O módulo 11 sempre devolve os dois Dígitos, pois, as vezes o dígito calculado no mod10 será incrementado em 1
+            return nossoNumero + dv1e2.ToString("00");
+        }
+
+        private string CalcularNCCodBarras(string seq)
+        {
+            int dv1 = Mod10Banri(seq);
+            int dv2 = Mod11Banri(seq, dv1);// O módulo 11 sempre devolve os dois Dígitos, pois, as vezes, o dígito calculado no mod10 será incrementado em 1
+            return dv2.ToString("00");
+        }
+
+        public override void FormataNossoNumero(Boleto boleto)
+        {
+            if (boleto.NossoNumero.Length == 10)
+            {
+                boleto.NossoNumero = boleto.NossoNumero.Substring(0, 8) + "-" + boleto.NossoNumero.Substring(8, 2);
+            }
+            else
+            {
+                throw new Exception("Erro ao tentar formatar nosso número, verifique o tamanho do campo");
+            }
+        }
+
+        public override void FormataNumeroDocumento(Boleto boleto)
+        {
+            throw new NotImplementedException("Função do formata número do documento não implementada.");
+        }
+
+        public override void FormataLinhaDigitavel(Boleto boleto)
+        {
+            string Campo1 = string.Empty;
+            string Campo2 = string.Empty;
+            string Campo3 = string.Empty;
+            string Campo4 = string.Empty;
+            string Campo5 = string.Empty;
+
+            string Metade1;
+            string Metade2;
+
+            string Cedente = boleto.Cedente.Codigo.Replace(".", "").Replace("-", ""); //Os quatro primeiros digitos do código do cedente é sempre a agência
+            string NossoNumero = boleto.NossoNumero.Substring(0, 8);
+
+            //(Isso depende da constante que usar) no caso de cima "041" no de baixo "40" antes do "XX"
+            if (boleto.TipoModalidade == "40")
+            {
+                /// <summary>
+                ///   IMPLEMENTAÇÃO PARA CONSTANTE 40 - INDICAM USO DA AGENCIA COM 4 DIGITOS
+                ///   Autor.: Felipe Silveira - Transis Software
+                ///   Data..: 06/07/2017
+                /// </summary>
+
+                //041M2.1AAAd1 ACCCCC.CCNNd2 NNNNN.N40XXd3 V FFFF9999999999
+
+                #region Campo 1
+
+                //Campo 1
+                Metade1 = string.Empty;
+                string M = boleto.Moeda.ToString();
+                string AAA = boleto.Cedente.ContaBancaria.Agencia.Substring(0, 3);
+                Metade1 = "041" + M + "2";
+
+                Metade2 = string.Empty;
+                Metade2 = "1" + AAA;
+                string d1 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo1 = Metade1 + "." + Metade2 + d1;
+
+                #endregion Campo 1
+
+                #region Campo 2
+
+                //Campo 2
+                Metade1 = string.Empty;
+                //Metade1 = Cedente.Substring(0, 5);
+                string A = boleto.Cedente.ContaBancaria.Agencia.Substring(3, 1);
+                string CCCC = boleto.Cedente.ContaBancaria.Conta.Substring(0, 4);
+                Metade1 = A + CCCC;
+
+                Metade2 = string.Empty;
+                //Metade2 = Cedente.Substring(5, 2) + NossoNumero.Substring(0, 3);
+                string CCC = boleto.Cedente.ContaBancaria.Conta.Substring(4, 3);
+                string NN = NossoNumero.Substring(0, 2);
+                Metade2 = CCC + NN;
+                string d2 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo2 = Metade1 + "." + Metade2 + d2;
+
+                #endregion Campo 2
+
+                #region Campo 3
+
+                //Campo 3
+                Metade1 = string.Empty;
+                string NNNNN = NossoNumero.Substring(2, 5);
+                Metade1 = NNNNN;
+
+                Metade2 = string.Empty;
+                string XX = _primDigito.ToString() + _segDigito.ToString();
+                string N = NossoNumero.Substring(7, 1);
+                Metade2 = N + "40" + XX;
+                string d3 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo3 = Metade1 + "." + Metade2 + d3;
+
+                #endregion Campo 3
+
+                #region Campo 4
+
+                //Campo 4
+                Campo4 = boleto.CodigoBarra.Codigo.Substring(4, 1);
+
+                #endregion Campo 4
+
+                #region Campo 5
+
+                //Campo 5
+                string fatorVenc = FatorVencimento(boleto).ToString("0000");
+                string valor = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                valor = Utils.FormatCode(valor, 10);
+                Campo5 = fatorVenc + valor;
+
+                #endregion Campo 5
+            }
+            else
+            {
+                //041M2.1AAAd1 CCCCC.CCNNNd2 NNNNN.041XXd3 V FFFF9999999999
+
+                #region Campo 1
+
+                //Campo 1
+                Metade1 = string.Empty;
+                Metade2 = string.Empty;
+                string M = boleto.Moeda.ToString();
+                string AAA = boleto.Cedente.ContaBancaria.Agencia.Substring(1, 3);
+                Metade1 = "041" + M + "2";
+                Metade2 = "1" + AAA;
+                string d1 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo1 = Metade1 + "." + Metade2 + d1;
+
+                #endregion Campo 1
+
+                #region Campo 2
+
+                //Campo 2
+                Metade1 = string.Empty;
+                Metade2 = string.Empty;
+                Metade1 = Cedente.Substring(0, 5);
+                //Metade2 = Cedente.Substring(5, 2) + NossoNumero.Substring(0, 2);
+                Metade2 = Cedente.Substring(5, 2) + NossoNumero.Substring(0, 3);
+                string d2 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo2 = Metade1 + "." + Metade2 + d2;
+
+                #endregion Campo 2
+
+                #region Campo 3
+
+                //Campo 3
+                Metade1 = string.Empty;
+                Metade2 = string.Empty;
+                string XX = _primDigito.ToString() + _segDigito.ToString();
+                //Metade1 = NossoNumero.Substring(2, 5);
+                Metade1 = NossoNumero.Substring(3, 5);
+                //Metade2 = NossoNumero.Substring(7, 1) + "041" + XX;
+                Metade2 = "041" + XX;
+                string d3 = Mod10Banri(Metade1 + Metade2).ToString();
+                Campo3 = Metade1 + "." + Metade2 + d3;
+
+                #endregion Campo 3
+
+                #region Campo 4
+
+                //Campo 4
+                Campo4 = boleto.CodigoBarra.Codigo.Substring(4, 1);
+
+                #endregion Campo 4
+
+                #region Campo 5
+
+                //Campo 5
+                string fatorVenc = FatorVencimento(boleto).ToString("0000");
+                string valor = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                valor = Utils.FormatCode(valor, 10);
+                Campo5 = fatorVenc + valor;
+
+                #endregion Campo 5
+            }
+
+            boleto.CodigoBarra.LinhaDigitavel = Campo1 + "  " + Campo2 + "  " + Campo3 + "  " + Campo4 + "  " + Campo5;
+        }
+
+        /// <summary>
+        ///   IMPLEMENTAÇÃO PARA CONSTANTE 40 - INDICAM USO DA AGENCIA COM 4 DIGITOS
+        ///   Autor.: Felipe Silveira - Transis Software
+        ///   Data..: 06/07/2017
+        /// </summary>
+        public override void FormataCodigoBarra(Boleto boleto)
+        {
+            string campo1;
+            string campo2;
+            string campoLivre;
+            int dacCodBarras;
+
+            if (boleto.TipoModalidade == "40")
+            {
+
+                //0419dFFFF999999999921AAAACCCCCCCNNNNNNNN40XX
+
+                campo1 = "041" + boleto.Moeda.ToString();
+                string fatorVenc = FatorVencimento(boleto).ToString("0000");
+                string valor = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                valor = Utils.FormatCode(valor, 10);
+                campo2 = fatorVenc + valor;
+
+                string nossoNumero = boleto.NossoNumero.Replace(".", "").Replace("-", "");
+                nossoNumero = nossoNumero.Substring(0, 8);
+
+                //11: 4 (agência) + 7 (cedente)
+                string codCedente = boleto.Cedente.Codigo.Replace(".", "").Replace("-", "").Substring(boleto.Cedente.Codigo.Length < 11 ? 0 : 4, 7);
+
+                campoLivre = "21" + boleto.Cedente.ContaBancaria.Agencia.Substring(0, 4) + codCedente + nossoNumero + "40";
+                string ncCodBarra = CalcularNCCodBarras(campoLivre);
+                int.TryParse(ncCodBarra.Substring(0, 1), out _primDigito);
+                int.TryParse(ncCodBarra.Substring(1, 1), out _segDigito);
+                campoLivre = campoLivre + ncCodBarra;
+
+                dacCodBarras = Mod11Peso2a9Banri(campo1 + campo2 + campoLivre);
+            }
+            else
+            {
+                //0419dFFFF999999999921AAACCCCCCCNNNNNNNN041XX
+
+                campo1 = "041" + boleto.Moeda.ToString();
+                string fatorVenc = FatorVencimento(boleto).ToString("0000");
+                string valor = boleto.ValorBoleto.ToString("f").Replace(",", "").Replace(".", "");
+                valor = Utils.FormatCode(valor, 10);
+                campo2 = fatorVenc + valor;
+
+                string nossoNumero = boleto.NossoNumero.Replace(".", "").Replace("-", "");
+                nossoNumero = nossoNumero.Substring(0, 8);
+
+                //11: 4 (agência) + 7 (cedente)
+                string codCedente = boleto.Cedente.Codigo.Substring(boleto.Cedente.Codigo.Length < 11 ? 0 : 4, 7);
+
+                campoLivre = "21" + boleto.Cedente.ContaBancaria.Agencia.Substring(1, 3) + codCedente + nossoNumero + "041";
+                string ncCodBarra = CalcularNCCodBarras(campoLivre);
+                int.TryParse(ncCodBarra.Substring(0, 1), out _primDigito);
+                int.TryParse(ncCodBarra.Substring(1, 1), out _segDigito);
+                campoLivre = campoLivre + ncCodBarra;
+
+                dacCodBarras = Mod11Peso2a9Banri(campo1 + campo2 + campoLivre);
+            }
+
+            boleto.CodigoBarra.Codigo = campo1 + dacCodBarras.ToString() + campo2 + campoLivre;
+        }
+
+        private static int Mod10Banri(string seq)
+        {
+            /* (N1*1-9) + (N2*2-9) + (N3*1-9) + (N4*2-9) + (N5*1-9) + (N6*2-9) + (N7*1-9) + (N8*2-9)
+             * Observação:
+             * a) a subtração do 9 somente será feita se o produto obtido da multiplicação individual for maior do que 9.
+             * b) quando o somatório for menor que 10, o resto da divisão por 10 será o próprio somatório.
+             * c) quando o resto for 0, o primeiro DV é igual a 0.
+             */
+            int soma = 0, resto, peso = 2;
+
+            for (int i = seq.Length - 1; i >= 0; i--)
+            {
+                int n = Convert.ToInt32(seq.Substring(i, 1));
+                int result = n * peso > 9 ? (n * peso) - 9 : n * peso;
+                soma += result;
+                peso = peso == 2 ? 1 : 2;
+            }
+
+            if (soma < 10)
+                resto = soma;
+            else
+                resto = soma % 10;
+            int dv1 = resto == 0 ? 0 : 10 - resto;
+            return dv1;
+        }
+
+        private int Mod11Banri(string seq, int dv1)
+        {
+            /* Obter somatório (peso de 2 a 7), sempre da direita para a esquerda (N1*4)+(N2*3)+(N3*2)+(N4*7)+(N5*6)+(N6*5)+(N7*4)+(N8*3)+(N9*2)
+             * Caso o somatório obtido seja menor que "11", considerar como resto da divisão o próprio somatório.
+             * Caso o ''resto'' obtido no cálculo do módulo ''11'' seja igual a ''1'', considera-se o DV inválido.
+             * Soma-se, então, "1" ao DV obtido do módulo "10" e refaz-se o cálculo do módulo 11 .
+             * Se o dígito obtido pelo módulo 10 era igual a "9", considera-se então (9+1=10) DV inválido.
+             * Neste caso, o DV do módulo "10" automaticamente será igual a "0" e procede-se assim novo cálculo pelo módulo "11".
+             * Caso o ''resto'' obtido no cálculo do módulo "11" seja ''0'', o segundo ''NC'' será igual ao próprio ''resto''
+             */
+            int peso = 2, mult, sum = 0, rest, dv2, b = 7, n;
+            seq += dv1.ToString();
+            bool dvInvalido;
+            for (int i = seq.Length - 1; i >= 0; i--)
+            {
+                n = Convert.ToInt32(seq.Substring(i, 1));
+                mult = n * peso;
+                sum += mult;
+                if (peso < b)
+                    peso++;
+                else
+                    peso = 2;
+            }
+            seq = seq.Substring(0, seq.Length - 1);
+            rest = sum < 11 ? sum : sum % 11;
+            if (rest == 1)
+                dvInvalido = true;
+            else
+                dvInvalido = false;
+
+            if (dvInvalido)
+            {
+                int novoDv1 = dv1 == 9 ? 0 : dv1 + 1;
+                dv2 = Mod11Banri(seq, novoDv1);
+            }
+            else
+            {
+                dv2 = rest == 0 ? 0 : 11 - rest;
+            }
+            if (!dvInvalido)
+            {
+                string digitos = dv1.ToString() + dv2;
+                return Convert.ToInt32(digitos);
+            }
+            else
+            {
+                return dv2;
+            }
+        }
+
+        private int Mod11BaseIndef(string seq, int b)
+        {
+            /* Variáveis
+             * -------------
+             * d - Dígito
+             * s - Soma
+             * p - Peso
+             * b - Base
+             * r - Resto
+             */
+
+            int d, s = 0, p = 2;
+
+
+            for (int i = seq.Length; i > 0; i--)
+            {
+                s = s + (Convert.ToInt32(seq.Mid(i, 1)) * p);
+                if (p == b)
+                    p = 2;
+                else
+                    p = p + 1;
+            }
+
+            d = 11 - (s % 11);
+
+
+            if ((d > 9) || (d == 0) || (d == 1))
+                d = 1;
+
+            return d;
+        }
+
+        private int Mod11Peso2a9Banri(string seq)
+        {
+            /* Variáveis
+             * -------------
+             * d - Dígito
+             * s - Soma
+             * p - Peso
+             * b - Base
+             * r - Resto
+             * n - Numero (string convertida)
+             */
+
+            int d, r, s = 0, p = 2, b = 9, n;
+
+            for (int i = seq.Length - 1; i >= 0; i--)
+            {
+                n = Convert.ToInt32(seq.Substring(i, 1));
+
+                s = s + (n * p);
+
+                if (p < b)
+                    p = p + 1;
+                else
+                    p = 2;
+            }
+
+            r = s % 11;
+
+            if (r == 0 || r == 1 || r > 9)
+                d = 1;
+            else
+                d = 11 - r;
+
+            return d;
+        }
+
+        private int CalculaSoma(string Numero)
+        {
+            int mult;
+            int x;
+            int y;
+            int resul;
+            int resto;
+            int soma;
+            soma = 0;
+            mult = 2;
+            int I = Numero.Length;
+            //para começar o cálculo pelo nº final (sempre começa multiplicando por 2)
+            for (x = 1; x <= Numero.Length; x++)
+            {
+                if (Codigo == 41)
+                {
+                    //Banrisul só vai até 7
+                    if (mult == 8)
+                        mult = 2;
+                }
+                else
+                {
+                    if (mult == 10)
+                        mult = 2;
+                }
+                y = Convert.ToInt32(Strings.Mid(Numero, I, 1));
+                resul = y * mult;
+                soma = soma + resul;
+                mult = mult + 1;
+                I = I - 1;
+            }
+            if (Codigo == 41 | Codigo == 33 | Codigo == 353)
+            {
+                return soma;
+                // calcula no retorno pois tem umas exceções
+            }
+            else
+            {
+                resto = soma % 11;
+                if (resto == 0)
+                    resto = 1;
+                return resto;
+            }
+        }
+
+        #region Métodos de validação e geração do arquivo remessa - sidneiklein
+        /// <summary>
+        /// Efetua as Validações dentro da classe Boleto, para garantir a geração da remessa
+        /// </summary>
+        public override bool ValidarRemessa(TipoArquivo tipoArquivo, string numeroConvenio, IBanco banco, Cedente cedente, Boletos boletos, int numeroArquivoRemessa, out string mensagem)
+        {
+            bool vRetorno = true;
+            string vMsg = string.Empty;
+            //
+            switch (tipoArquivo)
+            {
+                case TipoArquivo.CNAB240:
+                    vRetorno = ValidarRemessaCNAB240(numeroConvenio, banco, cedente, boletos, numeroArquivoRemessa, out vMsg);
+                    break;
+                case TipoArquivo.CNAB400:
+                    vRetorno = ValidarRemessaCNAB400(numeroConvenio, banco, cedente, boletos, numeroArquivoRemessa, out vMsg);
+                    break;
+                case TipoArquivo.Outro:
+                    throw new Exception("Tipo de arquivo inexistente.");
+            }
+            //
+            mensagem = vMsg;
+            return vRetorno;
+        }
+        /// <summary>
+        /// Gera o HEADER do arquivo remessa de acordo com o lay-out informado
+        /// </summary>
+        public override string GerarHeaderRemessa(string numeroConvenio, Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa)
+        {
+            try
+            {
+                string _header = " ";
+
+                base.GerarHeaderRemessa(numeroConvenio, cedente, tipoArquivo, numeroArquivoRemessa);
+
+                switch (tipoArquivo)
+                {
+
+                    case TipoArquivo.CNAB240:
+                        _header = GerarHeaderRemessaCNAB240();
+                        break;
+                    case TipoArquivo.CNAB400:
+                        _header = GerarHeaderRemessaCNAB400(int.Parse(numeroConvenio), cedente, numeroArquivoRemessa);
+                        break;
+                    case TipoArquivo.Outro:
+                        throw new Exception("Tipo de arquivo inexistente.");
+                }
+
+                return _header;
+
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do HEADER do arquivo de REMESSA.", ex);
+            }
+        }
+        /// <summary>
+        /// DETALHE do arquivo CNAB
+        /// Gera o DETALHE do arquivo remessa de acordo com o lay-out informado
+        /// </summary>
+        public override string GerarDetalheRemessa(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
+        {
+            try
+            {
+                string _detalhe = " ";
+
+                base.GerarDetalheRemessa(boleto, numeroRegistro, tipoArquivo);
+
+                switch (tipoArquivo)
+                {
+                    case TipoArquivo.CNAB240:
+                        _detalhe = GerarDetalheRemessaCNAB240();
+                        break;
+                    case TipoArquivo.CNAB400:
+                        _detalhe = GerarDetalheRemessaCNAB400(boleto, numeroRegistro, tipoArquivo);
+                        break;
+                    case TipoArquivo.Outro:
+                        throw new Exception("Tipo de arquivo inexistente.");
+                }
+
+                return _detalhe;
+
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do DETALHE arquivo de REMESSA.", ex);
+            }
+        }
+        /// <summary>
+        /// TRAILER do arquivo CNAB
+        /// Gera o TRAILER do arquivo remessa de acordo com o lay-out informado
+        /// </summary>
+        public override string GerarTrailerRemessa(int numeroRegistro, TipoArquivo tipoArquivo, Cedente cedente, decimal vltitulostotal)
+        {
+            try
+            {
+                string _trailer = " ";
+
+                base.GerarTrailerRemessa(numeroRegistro, tipoArquivo, cedente, vltitulostotal);
+
+                switch (tipoArquivo)
+                {
+                    case TipoArquivo.CNAB240:
+                        _trailer = GerarTrailerRemessa240();
+                        break;
+                    case TipoArquivo.CNAB400:
+                        _trailer = GerarTrailerRemessa400(numeroRegistro, vltitulostotal);
+                        break;
+                    case TipoArquivo.Outro:
+                        throw new Exception("Tipo de arquivo inexistente.");
+                }
+
+                return _trailer;
+
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("", ex);
+            }
+        }
+
+        public override string GerarHeaderRemessa(string numeroConvenio, Cedente cedente, TipoArquivo tipoArquivo, int numeroArquivoRemessa, Boleto boletos)
+        {
+            throw new NotImplementedException("Função não implementada.");
+        }
+        #endregion
+
+        #region CNAB 240
+        public bool ValidarRemessaCNAB240(string numeroConvenio, IBanco banco, Cedente cedente, Boletos boletos, int numeroArquivoRemessa, out string mensagem)
+        {
+            throw new NotImplementedException("Função não implementada.");
+        }
+        public string GerarHeaderRemessaCNAB240()
+        {
+            throw new NotImplementedException("Função não implementada.");
+        }
+        public string GerarDetalheRemessaCNAB240()
+        {
+            throw new NotImplementedException("Função não implementada.");
+        }
+        public string GerarTrailerRemessa240()
+        {
+            throw new NotImplementedException("Função não implementada.");
+        }
+        #endregion
+
+        #region CNAB 400 - sidneiklein
+
+        public bool ValidarRemessaCNAB400(string numeroConvenio, IBanco banco, Cedente cedente, Boletos boletos, int numeroArquivoRemessa, out string mensagem)
+        {
+            bool vRetorno = true;
+            string vMsg = string.Empty;
+            //
+            #region Pré Validações
+            if (banco == null)
+            {
+                vMsg += string.Concat("Remessa: O Banco é Obrigatório!", Environment.NewLine);
+                vRetorno = false;
+            }
+            if (cedente == null)
+            {
+                vMsg += string.Concat("Remessa: O Cedente/Beneficiário é Obrigatório!", Environment.NewLine);
+                vRetorno = false;
+            }
+            if (boletos == null || boletos.Count.Equals(0))
+            {
+                vMsg += string.Concat("Remessa: Deverá existir ao menos 1 boleto para geração da remessa!", Environment.NewLine);
+                vRetorno = false;
+            }
+            #endregion
+            //
+            foreach (Boleto boleto in boletos)
+            {
+                #region Validação de cada boleto
+                if (boleto.Remessa == null)
+                {
+                    vMsg += string.Concat("Boleto: ", boleto.NumeroDocumento, "; Remessa: Informe as diretrizes de remessa!", Environment.NewLine);
+                    vRetorno = false;
+                }
+                else
+                {
+                    #region Validações da Remessa que deverão estar preenchidas quando BANRISUL
+                    //Comentado porque ainda está fixado em 01
+                    //if (String.IsNullOrEmpty(boleto.Remessa.CodigoOcorrencia))
+                    //{
+                    //    vMsg += String.Concat("Boleto: ", boleto.NumeroDocumento, "; Remessa: Informe o Código de Ocorrência!", Environment.NewLine);
+                    //    vRetorno = false;
+                    //}
+                    if (string.IsNullOrEmpty(boleto.Remessa.TipoDocumento))
+                    {
+                        vMsg += string.Concat("Boleto: ", boleto.NumeroDocumento, "; Remessa: Informe o Tipo Documento!", Environment.NewLine);
+                        vRetorno = false;
+                    }
+                    else if (boleto.Remessa.TipoDocumento.Equals("06") && !string.IsNullOrEmpty(boleto.NossoNumero))
+                    {
+                        //Para o "Remessa.TipoDocumento = "06", não poderá ter NossoNumero Gerado!
+                        vMsg += string.Concat("Boleto: ", boleto.NumeroDocumento, "; Não pode existir NossoNumero para o Tipo Documento '06 - cobrança escritural'!", Environment.NewLine);
+                        vRetorno = false;
+                    }
+
+                    //Para o Tipo
+                    #endregion
+                }
+
+                boleto.NossoNumero = boleto.NossoNumero.Replace(",", "").Replace(".", "").Replace("-", "");
+
+                #endregion
+            }
+            //
+            mensagem = vMsg;
+            return vRetorno;
+        }
+
+        public string GerarHeaderRemessaCNAB400(int numeroConvenio, Cedente cedente, int numeroArquivoRemessa)
+        {
+            try
+            {
+                TRegistroEDI reg = new TRegistroEDI();
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0001, 010, 0, "01REMESSA", ' ')); //001-009
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0010, 016, 0, "", ' ')); //010-026
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0027, 013, 0, cedente.Codigo, ' ')); //027-039
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0040, 007, 0, "", ' ')); //040-046
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0047, 030, 0, cedente.Nome.ToUpper(), ' ')); //047-076
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0077, 011, 0, "041BANRISUL", ' ')); //077-087
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0088, 007, 0, "", ' ')); //088-094
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0095, 006, 0, DateTime.Now, ' ')); //095-100
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0101, 009, 0, "", ' ')); //101-109
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0110, 004, 0, "", ' ')); //110-113
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0114, 001, 0, "", ' ')); //114-114
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0115, 001, 0, "", ' ')); //115-115
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0116, 001, 0, "", ' ')); //116/116
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0117, 010, 0, "", ' ')); //117-126
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0127, 268, 0, "", ' ')); //126-394
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0395, 006, 0, "000001", ' ')); //395-400
+                //
+                reg.CodificarLinha();
+                //
+                string vLinha = reg.LinhaRegistro;
+                string _header = Utils.SubstituiCaracteresEspeciais(vLinha);
+                //
+                return _header;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao gerar HEADER do arquivo de remessa do CNAB400.", ex);
+            }
+        }
+
+        public string GerarDetalheRemessaCNAB400(Boleto boleto, int numeroRegistro, TipoArquivo tipoArquivo)
+        {
+            try
+            {
+                //Variáveis Locais a serem Implementadas em nível de Config do Boleto...
+                boleto.Remessa.CodigoOcorrencia = "01"; //remessa p/ bANRISUL
+                //
+                base.GerarDetalheRemessa(boleto, numeroRegistro, tipoArquivo);
+                //
+                TRegistroEDI reg = new TRegistroEDI();
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0001, 001, 0, "1", ' '));                                       //001-001
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 016, 0, string.Empty, ' '));                              //002-017
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0018, 013, 0, boleto.Cedente.Codigo, ' '));                     //018-030 (sidnei.klein 22/11/2013: No Banrisul, o Código do Cedente não é a concatenação de Número da Conta com o Dígito Verificador.)
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0031, 007, 0, string.Empty, ' '));                              //031-037
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 025, 0, boleto.NumeroDocumento, ' '));                    //038-062
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0063, 010, 0, boleto.NossoNumero, '0'));                        //063-072
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 032, 0, string.Empty, ' '));                              //073-104
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0105, 003, 0, string.Empty, ' '));                              //105-107
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0108, 001, 0, "1", ' '));                                       //108-108   //COBRANÇA SIMPLES
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, boleto.Remessa.CodigoOcorrencia, ' '));           //109-110   //REMESSA
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NumeroDocumento, ' '));                    //111-120
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0121, 006, 0, boleto.DataVencimento, ' '));                     //121-126
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0127, 013, 2, boleto.ValorBoleto, '0'));                        //127-139   //
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0140, 003, 0, "041", ' '));                                     //140-142
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0143, 005, 0, string.Empty, ' '));                              //143-147
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0148, 002, 0, boleto.Remessa.TipoDocumento, ' '));              //148-149
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0150, 001, 0, boleto.Aceite, ' '));                             //150-150
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediDataDDMMAA___________, 0151, 006, 0, boleto.DataProcessamento, ' '));                  //151-156
+                //
+                #region Instruções
+                string vQtdeDiasCodigo_9_ou_15 = "0";
+                //
+                string vInstrucao1 = string.Empty;
+                string vInstrucao2 = string.Empty;
+                switch (boleto.Instrucoes.Count)
+                {
+                    case 1:
+                        vInstrucao1 = boleto.Instrucoes[0].Codigo.ToString().PadLeft(2, '0');
+                        vInstrucao2 = string.Empty;
+                        //valida se é código 9 ou 15, para adicionar os dias na posição 370-371
+                        if (boleto.Instrucoes[0].Codigo == 9 || boleto.Instrucoes[0].Codigo == 15)
+                            vQtdeDiasCodigo_9_ou_15 = boleto.Instrucoes[0].QuantidadeDias.ToString();
+                        //
+                        break;
+                    case 2:
+                        vInstrucao1 += boleto.Instrucoes[0].Codigo.ToString().PadLeft(2, '0');
+                        //valida se é código 9 ou 15, para adicionar os dias na posição 370-371
+                        if (boleto.Instrucoes[0].Codigo == 9 || boleto.Instrucoes[0].Codigo == 15)
+                            vQtdeDiasCodigo_9_ou_15 = boleto.Instrucoes[0].QuantidadeDias.ToString();
+                        //
+                        vInstrucao2 += boleto.Instrucoes[1].Codigo.ToString().PadLeft(2, '0');
+                        //valida se é código 9 ou 15, para adicionar os dias na posição 370-371
+                        if (boleto.Instrucoes[1].Codigo == 9 || boleto.Instrucoes[1].Codigo == 15)
+                            vQtdeDiasCodigo_9_ou_15 = boleto.Instrucoes[1].QuantidadeDias.ToString();
+                        //
+                        break;
+                }
+                #endregion
+                //
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0157, 002, 0, vInstrucao1, ' '));                               //157-158
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0159, 002, 0, vInstrucao2, ' '));                               //159-160
+
+                if (string.IsNullOrEmpty(boleto.CodJurosMora))
+                {
+                    boleto.CodJurosMora = "0";
+                }
+
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0161, 001, 0, boleto.CodJurosMora, ' '));                       //161-161
+
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0162, 012, 2, boleto.JurosMora, '0'));                          //162-173
+                #region DataDesconto
+                string vDataDesconto = "000000";
+                if (!boleto.DataDesconto.Equals(DateTime.MinValue))
+                    vDataDesconto = boleto.DataDesconto.ToString("ddMMyy");
+                #endregion
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0174, 006, 0, vDataDesconto, '0'));                             //174-179
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0180, 013, 2, boleto.ValorDesconto, '0'));                      //180-192
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0193, 013, 2, boleto.IOF, '0'));                                //193-205
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0206, 013, 2, boleto.Abatimento, '0'));                         //206-218
+                #region Regra Tipo de Inscrição Sacado
+                string vCpfCnpjSac = "99";
+                if (boleto.Sacado.CPFCNPJ.Length.Equals(11)) vCpfCnpjSac = "01"; //Cpf é sempre 11;
+                else if (boleto.Sacado.CPFCNPJ.Length.Equals(14)) vCpfCnpjSac = "02"; //Cnpj é sempre 14;
+                #endregion
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0219, 002, 0, vCpfCnpjSac, '0'));                               //219-220
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 014, 0, boleto.Sacado.CPFCNPJ, '0'));                     //221-234
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0235, 035, 0, boleto.Sacado.Nome.ToUpper(), ' '));              //235-269
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0270, 005, 0, string.Empty, ' '));                              //270-274
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0275, 040, 0, boleto.Sacado.Endereco.EndComNumero.ToUpper(), ' '));      //275-314
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0315, 007, 0, string.Empty, ' '));                              //315-321
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0322, 003, 0, 0, '0'));                                         //322-324
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0325, 002, 0, 0, '0'));                                         //325-326
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0327, 008, 0, boleto.Sacado.Endereco.CEP, '0'));                //327-334
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0335, 015, 0, boleto.Sacado.Endereco.Cidade.ToUpper(), ' '));   //335-349
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0350, 002, 0, boleto.Sacado.Endereco.UF.ToUpper(), ' '));       //350-351
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0352, 004, 1, 0, '0'));                                         //352-355
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0356, 001, 0, string.Empty, ' '));                              //356-356
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0357, 013, 2, 0, '0'));                                         //357-369
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0370, 002, 0, vQtdeDiasCodigo_9_ou_15, '0'));                   //370-371
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0372, 023, 0, string.Empty, ' '));                              //372-394
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistro, '0'));                            //395-400
+                //
+
+                //
+                reg.CodificarLinha();
+                //
+                string _detalhe = Utils.SubstituiCaracteresEspeciais(reg.LinhaRegistro);
+                //
+                return _detalhe;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao gerar DETALHE do arquivo CNAB400.", ex);
+            }
+        }
+
+        public string GerarTrailerRemessa400(int numeroRegistro, decimal vltitulostotal)
+        {
+            try
+            {
+                TRegistroEDI reg = new TRegistroEDI();
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0001, 001, 0, "9", ' '));            //001-001
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 026, 0, string.Empty, ' '));   //002-027
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0028, 013, 2, vltitulostotal, '0')); //027-039
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0041, 354, 0, string.Empty, ' '));   //040-394
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistro, '0')); //395-400
+                //
+                reg.CodificarLinha();
+                //
+                string vLinha = reg.LinhaRegistro;
+                string _trailer = Utils.SubstituiCaracteresEspeciais(vLinha);
+                //
+                return _trailer;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a geração do registro TRAILER do arquivo de REMESSA.", ex);
+            }
+        }
+
+        public override HeaderRetorno LerHeaderRetornoCNAB400(string registro)
+        {
+            try
+            {
+                return new HeaderRetorno
+                {
+                    LiteralRetorno = registro.Substring(000, 19),
+                    CodigoEmpresa = registro.Substring(026, 12),
+                    NomeEmpresa = registro.Substring(046, 30),
+                    CodigoBanco = Utils.ToInt32(registro.Substring(076, 3)),
+                    NomeBanco = registro.Substring(079, 8),
+                    DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(094, 6)).ToString("##-##-##")),
+                    NumeroSequencialArquivoRetorno = Utils.ToInt32(registro.Substring(385, 8)),
+                    NumeroSequencial = Utils.ToInt32(registro.Substring(394, 6)),
+                };
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao ler header do arquivo de RETORNO / CNAB 400.", ex);
+            }
+        }
+
+        public override DetalheRetorno LerDetalheRetornoCNAB400(string registro)
+        {
+            try
+            {
+                TRegistroEDI_Banrisul_Retorno reg = new TRegistroEDI_Banrisul_Retorno { LinhaRegistro = registro };
+                reg.DecodificarLinha();
+
+                DetalheRetorno detalhe =
+                    new DetalheRetorno(registro)
+                    {
+                        CodigoInscricao = Utils.ToInt32(reg.TipoInscricao),
+                        NumeroInscricao = reg.CpfCnpj,
+                        NumeroControle = reg.IdentificacaoTituloCedente,
+                        IdentificacaoTitulo = reg.IdentificacaoTituloBanco_NossoNumero,
+                        CodigoOcorrencia = Utils.ToInt32(reg.CodigoOcorrencia),
+                        DataOcorrencia = Utils.ToDateTime(Utils.ToInt32(reg.DataOcorrenciaBanco).ToString("##-##-##")),
+                        NumeroDocumento = reg.SeuNumero,
+                        NossoNumeroComDV = reg.NossoNumero,
+                        NossoNumero = (reg.NossoNumero != null && reg.NossoNumero.Length >= 2) ? reg.NossoNumero.Substring(0, reg.NossoNumero.Length - 1) : string.Empty,
+                        DACNossoNumero = (reg.NossoNumero != null && reg.NossoNumero.Length >= 2) ? reg.NossoNumero.Substring(reg.NossoNumero.Length - 1) : string.Empty,
+                        DataVencimento = Utils.ToDateTime(Utils.ToInt32(reg.DataVencimentoTitulo).ToString("##-##-##")),
+                        ValorTitulo = Convert.ToInt64(reg.ValorTitulo) / divisor,
+                        CodigoBanco = Utils.ToInt32(reg.CodigoBancoCobrador),
+                        AgenciaCobradora = Utils.ToInt32(reg.CodigoAgenciaCobradora),
+                        ValorDespesa = Convert.ToUInt64(reg.ValorDespesasCobranca) / divisor,
+                        ValorOutrasDespesas = Convert.ToUInt64(reg.OutrasDespesas) / divisor,
+                        ValorAbatimento = Convert.ToUInt64(reg.ValorAbatimento_DeflacaoConcedido) / divisor,
+                        Descontos = Convert.ToUInt64(reg.ValorDescontoConcedido) / divisor,
+                        ValorPago = Convert.ToUInt64(reg.ValorPago) / divisor,
+                        JurosMora = Convert.ToUInt64(reg.ValorJuros) / divisor,
+                        OutrosCreditos = Convert.ToUInt64(reg.ValorOutrosRecebimentos) / divisor,
+                        DataCredito = Utils.ToDateTime(Utils.ToInt32(reg.DataCreditoConta).ToString("##-##-##")),
+                        OrigemPagamento = reg.PagamentoDinheiro_Cheque,
+                        MotivoCodigoOcorrencia = reg.MotivoOcorrencia,
+                        NumeroSequencial = Utils.ToInt32(reg.NumeroSequenciaRegistro),
+                        IOF = 0,
+                        MotivosRejeicao = string.Empty,
+                        NumeroCartorio = 0,
+                        NumeroProtocolo = string.Empty,
+                        NomeSacado = string.Empty
+                    };
+
+                return detalhe;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro ao ler detalhe do arquivo de RETORNO / CNAB 400.", ex);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/BoletoBancario.cs
+++ b/BoletoBancario.cs
@@ -1,0 +1,1428 @@
+using BoletoNet.Enums;
+using BoletoNet.Util;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
+//Envio por email
+using System.IO;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Reflection;
+using System.Text;
+using System.Web.UI;
+
+[assembly: WebResource("BoletoNet.BoletoImpressao.BoletoNet.css", "text/css", PerformSubstitution = true)]
+[assembly: WebResource("BoletoNet.Imagens.barra.gif", "image/gif")]
+//[assembly: WebResource("BoletoNet.Imagens.corte.gif", "image/gif")]
+//[assembly: WebResource("BoletoNet.Imagens.barrainterna.gif", "image/gif")]
+//[assembly: WebResource("BoletoNet.Imagens.ponto.gif", "image/gif")]
+
+namespace BoletoNet
+{
+    using System.Linq;
+
+    [Serializable(),
+    Designer(typeof(BoletoBancarioDesigner)),
+    ToolboxBitmap(typeof(BoletoBancario)),
+    ToolboxData("<{0}:BoletoBancario Runat=\"server\"></{0}:BoletoBancario>")]
+    public class BoletoBancario : Control
+    {
+        string vLocalLogoCedente = string.Empty;
+
+        #region Variaveis
+
+        private Banco _ibanco = null;
+        private short _codigoBanco = 0;
+        private Boleto _boleto;
+        private Cedente _cedente;
+        private Sacado _sacado;
+        private List<IInstrucao> _instrucoes = new List<IInstrucao>();
+        private string _instrucoesHtml = string.Empty;
+        private bool _mostrarCodigoCarteira = false;
+        private bool _formatoCarne = false;
+        private bool _ajustaTamanhoFonte = false;
+        private bool _removeSimboloMoedaValorDocumento = false;
+        private string _ajustaTamanhoFonteHtml;
+        #endregion Variaveis
+
+        #region Propriedades
+
+        [Browsable(true), Description("Remove o símbolo R$ do Valor do Documento")]
+        public bool RemoveSimboloMoedaValorDocumento
+        {
+            get { return _removeSimboloMoedaValorDocumento; }
+            set { _removeSimboloMoedaValorDocumento = value; }
+        }
+
+        [Browsable(true), Description("Código do banco em que será gerado o boleto. Ex. 341-Itaú, 237-Bradesco")]
+        public short CodigoBanco
+        {
+            get { return _codigoBanco; }
+            set { _codigoBanco = value; }
+        }
+
+        /// <summary>
+        /// Mostra o código da carteira
+        /// </summary>
+        [Browsable(true), Description("Mostra a descrição da carteira")]
+        public bool MostrarCodigoCarteira
+        {
+            get { return _mostrarCodigoCarteira; }
+            set { _mostrarCodigoCarteira = value; }
+        }
+
+        [Browsable(true), Description("Gera um relatório com os valores que deram origem ao boleto")]
+        public bool ExibirDemonstrativo { get; set; }
+
+        /// <summary>
+        /// Mostra o código da carteira
+        /// </summary>
+        [Browsable(true), Description("Formata o boleto no layout de carnê")]
+        public bool FormatoCarne
+        {
+            get { return _formatoCarne; }
+            set { _formatoCarne = value; }
+        }
+
+        [Browsable(false)]
+        public Boleto Boleto
+        {
+            get { return _boleto; }
+            set
+            {
+                _boleto = value;
+
+                if (_ibanco == null)
+                {
+                    _boleto.Banco = this.Banco;
+                    _boleto.BancoCarteira = BancoCarteiraFactory.Fabrica(_boleto.Carteira, Banco.Codigo);
+                }
+
+                _cedente = _boleto.Cedente;
+                _sacado = _boleto.Sacado;
+            }
+        }
+
+        [Browsable(false)]
+        public Sacado Sacado
+        {
+            get { return _sacado; }
+        }
+
+        [Browsable(false)]
+        public Cedente Cedente
+        {
+            get { return _cedente; }
+        }
+
+        [Browsable(false)]
+        public Banco Banco
+        {
+            get
+            {
+                if ((_ibanco == null) ||
+                    (_ibanco.Codigo != _codigoBanco))
+                {
+                    _ibanco = new Banco(_codigoBanco);
+                }
+
+                if (_boleto != null)
+                    _boleto.Banco = _ibanco;
+
+                return _ibanco;
+            }
+        }
+
+        /// <summary>
+        /// Caminho onde se encontra a ferramenta WkHtmlToPdf.
+        /// Se os arquivos do WkHtmlToPdf não estiverem presentes no caminho,
+        /// eles serão criados automaticamente pelo NReco PdfGenerator.
+        /// </summary>
+        [Browsable(true), Description("Caminho onde se encontra a ferramenta WkHtmlToPdf.")]
+        public string PdfToolPath { get; set; }
+
+        /// <summary>
+        /// Caminho onde a NReco gera os arquivos temporários necessários para a construção do PDF.
+        /// Se o caminho não for especificado a ferramenta utilizará a pasta retornada pelo método Path.GetTempPath().
+        /// </summary>
+        [Browsable(true), Description("Caminho onde a NReco gera os arquivos temporários necessários para a construção do PDF.")]
+        public string TempFilesPath { get; set; }
+
+        #region Propriedades
+        [Browsable(true), Description("Mostra o comprovante de entrega sem dados para marcar")]
+        public bool MostrarComprovanteEntregaLivre
+        {
+            get { return Utils.ToBool(ViewState["1"]); }
+            set { ViewState["1"] = value; }
+        }
+
+        [Browsable(true), Description("Mostra o comprovante de entrega")]
+        public bool MostrarComprovanteEntrega
+        {
+            get { return Utils.ToBool(ViewState["2"]); }
+            set { ViewState["2"] = value; }
+        }
+
+        [Browsable(true), Description("Oculta as intruções do boleto")]
+        public bool OcultarEnderecoSacado
+        {
+            get { return Utils.ToBool(ViewState["3"]); }
+            set { ViewState["3"] = value; }
+        }
+
+        [Browsable(true), Description("Oculta as intruções do boleto")]
+        public bool OcultarInstrucoes
+        {
+            get { return Utils.ToBool(ViewState["4"]); }
+            set { ViewState["4"] = value; }
+        }
+
+        [Browsable(true), Description("Oculta o recibo do sacado do boleto")]
+        public bool OcultarReciboSacado
+        {
+            get { return Utils.ToBool(ViewState["5"]); }
+            set { ViewState["5"] = value; }
+        }
+
+        [Browsable(true), Description("Gerar arquivo de remessa")]
+        public bool GerarArquivoRemessa
+        {
+            get { return Utils.ToBool(ViewState["6"]); }
+            set { ViewState["6"] = value; }
+        }
+        /// <summary> 
+        /// Mostra o termo "Contra Apresentação" na data de vencimento do boleto
+        /// </summary>
+        public bool MostrarContraApresentacaoNaDataVencimento
+        {
+            get { return Utils.ToBool(ViewState["7"]); }
+            set { ViewState["7"] = value; }
+        }
+
+        [Browsable(true), Description("Mostra o endereço do Cedente")]
+        public bool MostrarEnderecoCedente
+        {
+            get { return Utils.ToBool(ViewState["8"]); }
+            set { ViewState["8"] = value; }
+        }
+
+        [Browsable(true), Description("Mostra o endereço do Cedente no Recibo Cedente")]
+        public bool MostrarEnderecoCedentenoRecibo
+        {
+            get { return Utils.ToBool(ViewState["9"]); }
+            set { ViewState["9"] = value; }
+        }
+
+        [Browsable(true), Description("Mostra o endereço do Cedente sem Avalista")]
+        public bool MostrarEnderecoCedenteSemSacadorAvalista
+        {
+            get { return Utils.ToBool(ViewState["10"]); }
+            set { ViewState["10"] = value; }
+        }
+
+
+        #endregion Propriedades
+
+        /// <summary> 
+        /// Instruções disponíveis no Boleto
+        /// </summary>
+        public List<IInstrucao> Instrucoes
+        {
+            get
+            {
+                return _instrucoes;
+            }
+        }
+
+
+        #endregion Propriedades
+
+        public static string UrlLogo(int banco)
+        {
+            var page = System.Web.HttpContext.Current.CurrentHandler as Page;
+            return page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens." + Utils.FormatCode(banco.ToString(), 3) + ".jpg");
+        }
+
+        #region Override
+        protected override void OnPreRender(EventArgs e)
+        {
+            string alias = "BoletoNet.BoletoImpressao.BoletoNet.css";
+            string csslink = "<link rel=\"stylesheet\" type=\"text/css\" href=\"" +
+                Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), alias) + "\" />";
+
+            var include = new LiteralControl(csslink);
+            Page.Header.Controls.Add(include);
+
+            base.OnPreRender(e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+        }
+
+        [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.Demand, Name = "Execution")]
+        protected override void Render(HtmlTextWriter output)
+        {
+            if (_ibanco == null)
+            {
+                output.Write("<b>Erro gerando o boleto bancário: faltou definir o banco.</b>");
+                return;
+            }
+
+            string urlImagemLogo = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens." + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg");
+            string urlImagemBarra = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.barra.gif");
+            //string urlImagemBarraInterna = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.barrainterna.gif");
+            //string urlImagemCorte = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.corte.gif");
+            //string urlImagemPonto = Page.ClientScript.GetWebResourceUrl(typeof(BoletoBancario), "BoletoNet.Imagens.ponto.gif");
+
+            //Atribui os valores ao html do boleto bancário
+            //output.Write(MontaHtml(urlImagemCorte, urlImagemLogo, urlImagemBarra, urlImagemPonto, urlImagemBarraInterna,
+            //    "<img src=\"ImagemCodigoBarra.ashx?code=" + Boleto.CodigoBarra.Codigo + "\" alt=\"Código de Barras\" />"));
+            output.Write(MontaHtml(urlImagemLogo, urlImagemBarra, "<img src=\"ImagemCodigoBarra.ashx?code=" + Boleto.CodigoBarra.Codigo + "\" alt=\"Código de Barras\" />"));
+        }
+        #endregion Override
+
+        /// <summary>
+        /// Ajusta o tamanho dos textos e labels do boleto bancário.
+        /// </summary>
+        /// <param name="tamanhoFonteTextos">Padrão 10px</param>
+        /// <param name="tamanhoFonteRotulos">Padrão 9.8px. É o maior tamanho sem que o exista uma quebra de linha no rótulo "Data processamento"</param>
+        /// <param name="tamanhoFonteInstrucaoImpressao">Padrão 10px</param>
+        /// <param name="tamanhoFonteInstrucoes">Padrão 10px</param>
+        public void AjustaTamanhoFonte(double tamanhoFonteTextos = 10, double tamanhoFonteRotulos = 9.8, double tamanhoFonteInstrucaoImpressao = 9, double tamanhoFonteInstrucoes = 10)
+        {
+            _ajustaTamanhoFonte = true;
+
+            var html = new StringBuilder();
+
+            html.AppendLine("<style>");
+            html.AppendFormat(".cp$1 font-size: {0}px !important; $2", tamanhoFonteTextos);
+            html.AppendFormat(".ctN$1 font-size: {0}px !important; $2", tamanhoFonteRotulos);
+            html.AppendFormat(".cpN$1 font-size: {0}px !important; $2", tamanhoFonteTextos);
+            html.AppendFormat(".ti$1 font-size: {0}px !important; $2", tamanhoFonteInstrucaoImpressao);
+            html.AppendFormat(".ct$1 font-size: {0}px !important; $2", tamanhoFonteRotulos);
+            html.AppendFormat(".t$1 font-size: {0}px !important; $2", tamanhoFonteRotulos);
+            html.AppendFormat(".it$1 font-size: {0}px !important; $2", tamanhoFonteInstrucoes);
+            html.AppendLine("</style>");
+
+            _ajustaTamanhoFonteHtml = html.ToString().Replace("$1", "{").Replace("$2", "}");
+        }
+
+
+        #region Html
+        public string GeraHtmlInstrucoes()
+        {
+            try
+            {
+                var html = new StringBuilder();
+
+                string titulo = "Instruções de Impressão";
+                string instrucoes = "Imprimir em impressora jato de tinta (ink jet) ou laser em qualidade normal. (Não use modo econômico).<br>Utilize folha A4 (210 x 297 mm) ou Carta (216 x 279 mm) - Corte na linha indicada<br>";
+
+                html.Append(Html.Instrucoes);
+                html.Append("<br />");
+
+                return html.ToString()
+                    .Replace("@TITULO", titulo)
+                    .Replace("@INSTRUCAO", instrucoes);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a execução da transação.", ex);
+            }
+        }
+
+        private string GeraHtmlCarne(string htmlBoleto)
+        {
+            var html = new StringBuilder();
+
+            html.Append(Html.Carne);
+
+            return html.ToString()
+                .Replace("#BOLETO#", htmlBoleto);
+        }
+        public string GeraHtmlReciboSacado()
+        {
+            try
+            {
+                var html = new StringBuilder();
+
+                html.Append(Html.ReciboSacadoParte1);
+                html.Append("<br />");
+                html.Append(Html.ReciboSacadoParte2);
+                html.Append(Html.ReciboSacadoParte3);
+
+                if (MostrarEnderecoCedenteSemSacadorAvalista)
+                {
+                    html.Append(Html.ReciboSacadoParte10SemSacador);
+                }
+                else if (MostrarEnderecoCedente)
+                {
+                    html.Append(Html.ReciboSacadoParte10);
+                }
+
+                html.Append(Html.ReciboSacadoParte4);
+                html.Append(Html.ReciboSacadoParte5);
+                html.Append(Html.ReciboSacadoParte6);
+                html.Append(Html.ReciboSacadoParte7);
+
+                //if (Instrucoes.Count == 0)
+                html.Append(Html.ReciboSacadoParte8);
+
+                //Limpa as intruções para o Sacado
+                _instrucoesHtml = "";
+
+                MontaInstrucaoCaixa();
+
+                MontaInstrucoes(Boleto.Instrucoes);
+
+                if (Boleto.Sacado.Instrucoes.Count > 0)
+                    MontaInstrucoes(Boleto.Sacado.Instrucoes);
+
+                return html.ToString().Replace("@INSTRUCOES", _instrucoesHtml);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro durante a execução da transação.", ex);
+            }
+        }
+
+        public string GeraHtmlReciboCedente()
+        {
+            try
+            {
+                var html = new StringBuilder();
+
+                html.Append(Html.ReciboCedenteParte1);
+                html.Append(Html.ReciboCedenteParte2);
+                html.Append(MostrarEnderecoCedentenoRecibo ? Html.ReciboCedenteParte13 : Html.ReciboCedenteParte3);
+                html.Append(Html.ReciboCedenteParte4);
+                html.Append(Html.ReciboCedenteParte5);
+                html.Append(Html.ReciboCedenteParte6);
+                html.Append(Html.ReciboCedenteParte7);
+                html.Append(Html.ReciboCedenteParte8);
+                html.Append(Html.ReciboCedenteParte9);
+                html.Append(Html.ReciboCedenteParte10);
+                html.Append(Html.ReciboCedenteParte11);
+                html.Append(Html.ReciboCedenteParte12);
+
+                //Para Banco Itaú, o texto "(Texto de responsabilidade do cedente)" deve ser
+                //"(Todas as informações deste bloqueto são de exclusiva responsabilidade do cedente)".
+                if (Boleto.Banco.Codigo == 341)
+                {
+                    html.Replace("(Texto de responsabilidade do cedente)", "(Todas as informações deste bloqueto são de exclusiva responsabilidade do cedente)");
+                }
+
+                //Para carteiras "17-019" e "18-019" do Banco do Brasil, a ficha de compensação não possui código da carteira
+                //na formatação do campo.
+                if (Boleto.Banco.Codigo == 1 & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("17-027") | Boleto.Carteira.Equals("17-051") | Boleto.Carteira.Equals("18-019") | Boleto.Carteira.Equals("17-159") | Boleto.Carteira.Equals("17-140") | Boleto.Carteira.Equals("17-067")))
+                {
+                    html.Replace("Carteira /", "");
+                    html.Replace("@NOSSONUMERO", "@NOSSONUMEROBB");
+                }
+                else
+                {
+                    //Para SANTANDER, a ficha de compensação não possui código da carteira - por jsoda em 08/12/2012
+                    if (Boleto.Banco.Codigo == 33)
+                    {
+                        html.Replace("Carteira /", "");
+                    }
+                }
+
+                //Limpa as intruções para o Cedente
+                _instrucoesHtml = "";
+
+                MontaInstrucaoCaixa();
+
+                MontaInstrucoes(Boleto.Instrucoes);
+
+                if (Boleto.Cedente.Instrucoes.Count > 0)
+                    MontaInstrucoes(Boleto.Cedente.Instrucoes);
+
+                return html.ToString().Replace("@INSTRUCOES", _instrucoesHtml);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Erro na execução da transação.", ex);
+            }
+        }
+
+        private void MontaInstrucaoCaixa()
+        {
+            //Suelton - 12/03/2018
+            //Para homologação da Caixa é obrigatório ter as informações do SAC
+            if (Banco.Codigo == 104)
+            {
+                //_instrucoesHtml = _instrucoesHtml +
+                //                  "<br><br><p>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)</p> <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 </p><p> Ouvidoria: 0800 725 7474 - caixa.gov.br </p>";
+                _instrucoesHtml = _instrucoesHtml +
+                                  "<br>SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios)<br/> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 Ouvidoria: 0800 725 7474 <br/> caixa.gov.br";
+            }
+        }
+
+        public string HtmlComprovanteEntrega
+        {
+            get
+            {
+                var html = new StringBuilder();
+
+                html.Append(Html.ComprovanteEntrega1);
+                html.Append(Html.ComprovanteEntrega2);
+                html.Append(Html.ComprovanteEntrega3);
+                html.Append(Html.ComprovanteEntrega4);
+                html.Append(Html.ComprovanteEntrega5);
+                html.Append(Html.ComprovanteEntrega6);
+
+                html.Append(MostrarComprovanteEntregaLivre ? Html.ComprovanteEntrega71 : Html.ComprovanteEntrega7);
+
+                html.Append("<br />");
+                return html.ToString();
+            }
+        }
+
+        private void MontaInstrucoes(IList<IInstrucao> instrucoes)
+        {
+            if (!string.IsNullOrEmpty(_instrucoesHtml))
+                _instrucoesHtml = string.Concat(_instrucoesHtml, "<br />");
+
+            if (instrucoes.Count > 0 || Banco.Codigo == 104)
+            {
+                //_instrucoesHtml = string.Empty;
+                //Flavio(fhlviana@hotmail.com) - retirei a tag <span> de cada instrução por não ser mais necessáras desde que dentro
+                //da div que contem as instruções a classe cpN se aplica, que é a mesma, em conteudo, da classe cp
+                foreach (IInstrucao instrucao in instrucoes)
+                {
+                    _instrucoesHtml += string.Format("{0}<br />", instrucao.Descricao);
+
+                    //Adiciona a instrução as instruções disponíveis no Boleto
+                    Instrucoes.Add(instrucao);
+                }
+
+                if (instrucoes.Any())
+                    _instrucoesHtml = _instrucoesHtml.Left(_instrucoesHtml.Length - 6);
+            }
+        }
+
+        private string MontaHtml(string urlImagemLogo, string urlImagemBarra, string imagemCodigoBarras)
+        {
+            var html = new StringBuilder();
+            string enderecoCedente = "";
+
+            if (_ajustaTamanhoFonte)
+            {
+                html.Append(_ajustaTamanhoFonteHtml);
+            }
+
+            //Oculta o cabeçalho das instruções do boleto
+            if (!OcultarInstrucoes)
+                html.Append(GeraHtmlInstrucoes());
+
+            if (this.ExibirDemonstrativo && this.Boleto.Demonstrativos.Any())
+            {
+                html.Append(Html.ReciboCedenteRelatorioValores);
+                html.Append(Html.ReciboCedenteParte5);
+
+                html.Append(Html.CabecalhoTabelaDemonstrativo);
+
+                var grupoDemonstrativo = new StringBuilder();
+
+                foreach (var relatorio in this.Boleto.Demonstrativos)
+                {
+                    var first = true;
+
+                    foreach (var item in relatorio.Itens)
+                    {
+                        grupoDemonstrativo.Append(Html.GrupoDemonstrativo);
+
+                        if (first)
+                        {
+                            grupoDemonstrativo = grupoDemonstrativo.Replace("@DESCRICAOGRUPO", relatorio.Descricao);
+
+                            first = false;
+                        }
+                        else
+                        {
+                            grupoDemonstrativo = grupoDemonstrativo.Replace("@DESCRICAOGRUPO", string.Empty);
+                        }
+
+                        grupoDemonstrativo = grupoDemonstrativo.Replace("@DESCRICAOITEM", item.Descricao);
+                        grupoDemonstrativo = grupoDemonstrativo.Replace("@REFERENCIAITEM", item.Referencia);
+                        grupoDemonstrativo = grupoDemonstrativo.Replace("@VALORITEM", item.Valor.ToString("R$ ##,##0.00"));
+                    }
+
+                    grupoDemonstrativo.Append(Html.TotalDemonstrativo);
+                    grupoDemonstrativo = grupoDemonstrativo.Replace(
+                        "@VALORTOTALGRUPO",
+                        relatorio.Itens.Sum(c => c.Valor).ToString("R$ ##,##0.00"));
+                }
+
+                html = html.Replace("@ITENSDEMONSTRATIVO", grupoDemonstrativo.ToString());
+            }
+
+            if (!FormatoCarne)
+            {
+                //Mostra o comprovante de entrega
+                if (MostrarComprovanteEntrega | MostrarComprovanteEntregaLivre)
+                {
+                    html.Append(HtmlComprovanteEntrega);
+                    //Html da linha pontilhada
+                    if (OcultarReciboSacado)
+                        html.Append(Html.ReciboSacadoParte8);
+                }
+
+                //Oculta o recibo do sacabo do boleto
+                if (!OcultarReciboSacado)
+                {
+                    html.Append(GeraHtmlReciboSacado());
+
+                    //Caso mostre o Endereço do Cedente
+                    if (MostrarEnderecoCedente)
+                    {
+                        if (Cedente.Endereco == null)
+                            throw new ArgumentNullException("Endereço do Cedente");
+
+                        string Numero = !string.IsNullOrEmpty(Cedente.Endereco.Numero) ? Cedente.Endereco.Numero + ", " : "";
+                        enderecoCedente = string.Concat(Cedente.Endereco.End, " , ", Numero);
+
+                        if (Cedente.Endereco.CEP == string.Empty)
+                        {
+                            enderecoCedente += string.Format("{0} - {1}/{2}", Cedente.Endereco.Bairro,
+                                                             Cedente.Endereco.Cidade, Cedente.Endereco.UF);
+                        }
+                        else
+                        {
+                            enderecoCedente += string.Format("{0} - {1}/{2} - CEP: {3}", Cedente.Endereco.Bairro,
+                                                             Cedente.Endereco.Cidade, Cedente.Endereco.UF,
+                                                             Utils.FormataCEP(Cedente.Endereco.CEP));
+                        }
+
+                    }
+                }
+            }
+
+            string sacado = "";
+            string cpfCnpj = string.Empty;
+            //Flavio(fhlviana@hotmail.com) - adicionei a possibilidade de o boleto não ter, necessáriamente, que informar o CPF ou CNPJ do sacado.
+            //Formata o CPF/CNPJ(se houver) e o Nome do Sacado para apresentação
+            if (Sacado.CPFCNPJ == string.Empty)
+            {
+                sacado = Sacado.Nome;
+            }
+            else
+            {
+                sacado = Sacado.CPFCNPJ.Length <= 11
+                    ? string.Format("{0}  CPF: {1}", Sacado.Nome, Utils.FormataCPF(Sacado.CPFCNPJ))
+                    : string.Format("{0}  CNPJ: {1}", Sacado.Nome, Utils.FormataCNPJ(Sacado.CPFCNPJ));
+            }
+
+            if (!string.IsNullOrEmpty(Cedente.CPFCNPJ))
+            {
+                cpfCnpj = Cedente.CPFCNPJ.Length <= 11 ? Utils.FormataCPF(Cedente.CPFCNPJ) : Utils.FormataCNPJ(Cedente.CPFCNPJ);
+            }
+
+            string infoSacado = Sacado.InformacoesSacado.GeraHTML(false);
+
+            //Caso não oculte o Endereço do Sacado,
+            if (!OcultarEnderecoSacado)
+            {
+                string enderecoSacado = "";
+
+                if (Sacado.Endereco.CEP == string.Empty)
+                    enderecoSacado = string.Format("{0} - {1}/{2}", Sacado.Endereco.Bairro, Sacado.Endereco.Cidade, Sacado.Endereco.UF);
+                else
+                    enderecoSacado = string.Format("{0} - {1}/{2} - CEP: {3}", Sacado.Endereco.Bairro,
+                    Sacado.Endereco.Cidade, Sacado.Endereco.UF, Utils.FormataCEP(Sacado.Endereco.CEP));
+
+                if (Sacado.Endereco.End != string.Empty && enderecoSacado != string.Empty)
+                {
+                    string Numero = !string.IsNullOrEmpty(Sacado.Endereco.Numero) ? ", " + Sacado.Endereco.Numero : "";
+
+                    if (infoSacado == string.Empty)
+                        infoSacado += InfoSacado.Render(Sacado.Endereco.End + Numero, enderecoSacado, false);
+                    else
+                        infoSacado += InfoSacado.Render(Sacado.Endereco.End + Numero, enderecoSacado, true);
+                }
+                //"Informações do Sacado" foi introduzido para possibilitar que o boleto na informe somente o endereço do sacado
+                //como em outras situaçoes onde se imprime matriculas, codigos e etc, sobre o sacado.
+                //Sendo assim o endereço do sacado passa a ser uma Informaçao do Sacado que é adicionada no momento da renderização
+                //de acordo com a flag "OcultarEnderecoSacado"
+            }
+
+            string agenciaConta = Utils.FormataAgenciaConta(Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Cedente.ContaBancaria.Conta, Cedente.ContaBancaria.DigitoConta);
+
+            // Trecho adicionado por Fabrício Nogueira de Almeida :fna - fnalmeida@gmail.com - 09/12/2008
+            /* Esse código foi inserido pq no campo Agência/Cod Cedente, estava sendo impresso sempre a agência / número da conta
+			 * No boleto da caixa que eu fiz, coloquei no método validarBoleto um trecho para calcular o dígito do cedente, e adicionei esse atributo na classe cedente
+			 * O trecho abaixo testa se esse digito foi calculado, se foi insere no campo Agencia/Cod Cedente, a agência e o código com seu digito
+			 * caso contrário mostra a agência / conta, como era anteriormente.
+			 * Com esse código ele ira atender as necessidades do boleto caixa e não afetará os demais
+			 * Caso queira que apareça o Agência/cod. cedente para outros boletos, basta calcular e setar o digito, como foi feito no boleto Caixa 
+			 */
+
+            string agenciaCodigoCedente;
+
+            if (!Cedente.DigitoCedente.Equals(-1))
+            {
+                //if (!string.IsNullOrEmpty(Cedente.ContaBancaria.OperacaConta))
+                //    agenciaCodigoCedente = string.Format("{0}/{1}.{2}-{3}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.OperacaConta, Utils.FormatCode(Cedente.Codigo, 6), Cedente.DigitoCedente);
+
+                switch (Boleto.Banco.Codigo)
+                {
+                    case (int)Bancos.Sicredi:
+                        agenciaCodigoCedente = string.Format("{0}.{1}.{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.OperacaConta, Utils.FormatCode(Cedente.ContaBancaria.Conta, 5));
+                        break;
+                    case (int)Bancos.Banrisul:
+                        var codigo = Cedente.Codigo;
+                        if (Cedente.Codigo.Substring(0, 4).Equals(Cedente.ContaBancaria.Agencia))
+                            //RETIRA OS DIGITOS DA AGENCIA SE ESTIVEREM JUNTOS NO CODIGO DA CONTA
+                            codigo = Cedente.Codigo.Substring(4, codigo.Length - 4);
+                        var dig1 = codigo.Substring(0, codigo.Length - (Cedente.DigCedente.Length + 1));
+                        var dig2 = codigo.Substring((codigo.Length - (Cedente.DigCedente.Length + 1)), 1);
+
+                        agenciaCodigoCedente = string.Format("{0}/{1}.{2}.{3}", Cedente.ContaBancaria.Agencia, dig1, dig2, Cedente.DigCedente);
+
+                        //agenciaCodigoCedente = string.Format("{0}.{1}/{2}.{3}.{4}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Cedente.Codigo.Substring(4, 6), Cedente.Codigo.Substring(10, 1), Cedente.DigitoCedente);
+                        break;
+                    case (int)Bancos.BancoBrasil:
+                        agenciaCodigoCedente = string.Format("{0}-{1}/{2}-{3}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Utils.FormatCode(Cedente.ContaBancaria.Conta, 6), Cedente.ContaBancaria.DigitoConta);
+                        break;
+                    case (int)Bancos.HSBC:
+                        agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo + Cedente.DigitoCedente, 7));
+                        break;
+                    default:
+                        agenciaCodigoCedente = string.Format("{0}/{1}-{2}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 6), Cedente.DigitoCedente);
+                        break;
+                }
+            }
+            else
+            {
+                //Para banco SANTANDER, a formatação do campo "Agencia/Identif.Cedente" - por jsoda em 07/05/2012
+                switch (Boleto.Banco.Codigo)
+                {
+                    case (int)Bancos.Santander:
+                        agenciaCodigoCedente = string.Format("{0}-{1}/{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.DigitoAgencia, Utils.FormatCode(Cedente.Codigo, 6));
+                        if (string.IsNullOrEmpty(Cedente.ContaBancaria.DigitoAgencia))
+                        {
+                            agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 6));
+                            if (Utils.FormatCode(Cedente.Codigo, 6).Equals("000000"))
+                            {
+                                agenciaCodigoCedente = String.Format("{0}/{1}-{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.Conta, Cedente.ContaBancaria.DigitoConta);
+                            }
+                        }
+                        break;
+                    case (int)Bancos.HSBC:
+                        agenciaCodigoCedente = string.Format("{0}/{1}", Cedente.ContaBancaria.Agencia, Utils.FormatCode(Cedente.Codigo, 7)); //Solicitação do HSBC que mostrasse agencia/Conta - por Transis em 24/02/15
+                        break;
+                    case (int)Bancos.Sicredi:
+                        agenciaCodigoCedente = string.Format("{0}.{1}.{2}", Cedente.ContaBancaria.Agencia, Cedente.ContaBancaria.OperacaConta, Utils.FormatCode(Cedente.ContaBancaria.Conta, 5));
+                        break;
+                    default:
+                        agenciaCodigoCedente = agenciaConta;
+                        break;
+                }
+            }
+
+            html.Append(!FormatoCarne ? GeraHtmlReciboCedente() : GeraHtmlCarne(GeraHtmlReciboCedente()));
+
+            string dataVencimento = Boleto.DataVencimento.ToString("dd/MM/yyyy");
+
+            if (MostrarContraApresentacaoNaDataVencimento)
+                dataVencimento = "Contra Apresentação";
+
+            if (string.IsNullOrEmpty(vLocalLogoCedente))
+                vLocalLogoCedente = urlImagemLogo;
+
+            var valorBoleto = (Boleto.ValorBoleto == 0 ? "" : Boleto.ValorBoleto.ToString("C", CultureInfo.GetCultureInfo("PT-BR")));
+
+            return html.Replace("@CODIGOBANCO", Utils.FormatCode(_ibanco.Codigo.ToString(), 3))
+                .Replace("@DIGITOBANCO", _ibanco.Digito)
+                //.Replace("@URLIMAGEMBARRAINTERNA", urlImagemBarraInterna)
+                //.Replace("@URLIMAGEMCORTE", urlImagemCorte)
+                //.Replace("@URLIMAGEMPONTO", urlImagemPonto)
+                .Replace("@URLIMAGEMLOGO", urlImagemLogo)
+                .Replace("@URLIMGCEDENTE", vLocalLogoCedente)
+                .Replace("@URLIMAGEMBARRA", urlImagemBarra)
+                .Replace("@LINHADIGITAVEL", Boleto.CodigoBarra.LinhaDigitavel)
+                .Replace("@LOCALPAGAMENTO", Boleto.LocalPagamento)
+                .Replace("@DATAVENCIMENTO", dataVencimento)
+                .Replace(
+                    "@CEDENTE_BOLETO",
+                    !Cedente.MostrarCNPJnoBoleto
+                        ? Cedente.Nome
+                        : string.Format("{0}&nbsp;&nbsp;&nbsp;CNPJ: {1}", Cedente.Nome, Cedente.CPFCNPJcomMascara))
+                .Replace("@CEDENTE", Cedente.Nome)
+                .Replace("@DATADOCUMENTO", Boleto.DataDocumento.ToString("dd/MM/yyyy"))
+                .Replace("@NUMERODOCUMENTO", Boleto.NumeroDocumento)
+                .Replace("@ESPECIEDOCUMENTO", EspecieDocumento.ValidaSigla(Boleto.EspecieDocumento))
+                .Replace("@DATAPROCESSAMENTO", Boleto.DataProcessamento.ToString("dd/MM/yyyy"))
+
+            #region Implementação para o Banco do Brasil
+
+                //Variável inserida para atender às especificações das carteiras "17-019", "17-027", "17-051" e "18-019" do Banco do Brasil
+                //apenas para a ficha de compensação.
+                //Como a variável não existirá se não forem as carteiras "17-019", "17-027", "17-051", "17-019", "17-035", "17-140", "17-159", "17-067", "17-167" e "18-019", não foi colocado o [if].
+                .Replace(
+                    "@NOSSONUMEROBB",
+                    Boleto.Banco.Codigo == 1
+                    & (Boleto.Carteira.Equals("17-019") | Boleto.Carteira.Equals("17-027") | Boleto.Carteira.Equals("17-051") | Boleto.Carteira.Equals("17-035")
+                        | Boleto.Carteira.Equals("18-019") | Boleto.Carteira.Equals("17-140") | Boleto.Carteira.Equals("17-159")
+                        | Boleto.Carteira.Equals("17-067") | Boleto.Carteira.Equals("17-167"))
+                        ? Boleto.NossoNumero.Substring(3)
+                        : string.Empty)
+            #endregion Implementação para o Banco do Brasil
+
+                .Replace("@NOSSONUMERO", Boleto.NossoNumero)
+                .Replace("@CARTEIRA", FormataDescricaoCarteira())
+                .Replace("@ESPECIE", Boleto.Especie)
+                .Replace("@QUANTIDADE", (Boleto.QuantidadeMoeda == 0 ? "" : Boleto.QuantidadeMoeda.ToString()))
+                .Replace("@VALORDOCUMENTO", Boleto.ValorMoeda)
+                .Replace("@=VALORDOCUMENTO", valorBoleto)
+                .Replace(
+                    "@VALORCOBRADO",
+                    (Boleto.ValorCobrado == 0 ? "" : Boleto.ValorCobrado.ToString("C", CultureInfo.GetCultureInfo("PT-BR"))))
+                .Replace("@OUTROSACRESCIMOS", "")
+                .Replace("@OUTRASDEDUCOES", "")
+                .Replace(
+                    "@DESCONTOS",
+                    (Boleto.ValorDesconto == 0 ? "" : Boleto.ValorDesconto.ToString("C", CultureInfo.GetCultureInfo("PT-BR"))))
+                .Replace("@AGENCIACONTA", agenciaCodigoCedente)
+                .Replace("@SACADO", sacado)
+                .Replace("@INFOSACADO", infoSacado)
+                .Replace("@AGENCIACODIGOCEDENTE", agenciaCodigoCedente)
+                .Replace("@CPFCNPJ", Cedente.CPFCNPJ)
+                .Replace(
+                    "@MORAMULTA",
+                    (Boleto.ValorMulta == 0 ? "" : Boleto.ValorMulta.ToString("C", CultureInfo.GetCultureInfo("PT-BR"))))
+                .Replace("@AUTENTICACAOMECANICA", "")
+                .Replace("@USODOBANCO", Boleto.UsoBanco)
+                .Replace("@IMAGEMCODIGOBARRA", imagemCodigoBarras)
+                .Replace("@ACEITE", Boleto.Aceite)
+                .ToString()
+                .Replace("@ENDERECOCEDENTE", MostrarEnderecoCedente ? enderecoCedente : "")
+                .Replace(
+                    "@AVALISTA",
+                    string.Format(
+                        "{0} - {1}",
+                        Boleto.Avalista != null ? Boleto.Avalista.Nome : string.Empty,
+                        Boleto.Avalista != null ? Boleto.Avalista.CPFCNPJ : string.Empty))
+                .Replace("Ar\">R$", RemoveSimboloMoedaValorDocumento ? "Ar\">" : "Ar\">R$")
+                .Replace("@PARCELATOTAL", Boleto.NumeroParcela != 0 && Boleto.TotalParcela != 0 ? Boleto.NumeroParcela + " / " + Boleto.TotalParcela : string.Empty)
+                .Replace("@DADOSCEDENTE", MostrarEnderecoCedentenoRecibo ? Cedente.Nome + " " + cpfCnpj + " " + enderecoCedente : "");
+        }
+
+        private string FormataDescricaoCarteira()
+        {
+            if (MostrarCodigoCarteira)
+            {
+                string descricaoCarteira = "";
+                int carteira = Utils.ToInt32(Boleto.Carteira);
+
+                switch (Banco.Codigo)
+                {
+                    case 1:
+                        descricaoCarteira = new Carteira_BancoBrasil(carteira).Codigo;
+                        break;
+                    case 353:
+                    case 8:
+                    case 33:
+                        descricaoCarteira = new Carteira_Santander(carteira).Codigo;
+                        break;
+                    case 104:
+                        descricaoCarteira = new Carteira_Caixa(carteira).Codigo;
+                        break;
+                    case 341:
+                        descricaoCarteira = new Carteira_Itau(carteira).Codigo;
+                        break;
+
+                    default:
+                        throw new Exception(string.Format("A descrição para o banco {0} não foi implementada.", Boleto.Banco));
+
+                }
+
+                if (string.IsNullOrEmpty(descricaoCarteira))
+                {
+                    throw new Exception("O código da carteira não foi implementado.");
+                }
+
+                return string.Format("{0} - {1}", Boleto.Carteira,
+                     descricaoCarteira);
+            }
+            return Boleto.Carteira;
+        }
+
+        #endregion Html
+
+        #region Geração do Html OffLine
+
+        /// <summary>
+        /// Função utilizada para gerar o html do boleto sem que o mesmo esteja dentro de uma página Web.
+        /// </summary>
+        /// <param name="srcLogo">Local apontado pela imagem de logo.</param>
+        /// <param name="srcBarra">Local apontado pela imagem de barra.</param>
+        /// <param name="srcCodigoBarra">Local apontado pela imagem do código de barras.</param>
+        /// <returns>StringBuilder conténdo o código html do boleto bancário.</returns>
+        protected StringBuilder HtmlOffLine(string textoNoComecoDoEmail, string srcLogo, string srcBarra, string srcCodigoBarra, bool usaCSSPDF = false, bool imprimeHeader = true, bool imprimeFooter = true)
+        {//protected StringBuilder HtmlOffLine(string srcCorte, string srcLogo, string srcBarra, string srcPonto, string srcBarraInterna, string srcCodigoBarra)
+            this.OnLoad(EventArgs.Empty);
+
+            StringBuilder html = new StringBuilder();
+            if (imprimeHeader)
+                HtmlOfflineHeader(html, usaCSSPDF);
+            if (!string.IsNullOrEmpty(textoNoComecoDoEmail))
+            {
+                html.Append(textoNoComecoDoEmail);
+            }
+            html.Append(MontaHtml(srcLogo, srcBarra, "<img src=\"" + srcCodigoBarra + "\" alt=\"Código de Barras\" />"));
+            if (imprimeFooter)
+                HtmlOfflineFooter(html);
+
+            return html;
+        }
+
+        /// <summary>
+        /// Monta o Header de um email com pelo menos um boleto dentro.
+        /// </summary>
+        /// <param name="saida">StringBuilder onde o conteudo sera salvo.</param>
+        protected static void HtmlOfflineHeader(StringBuilder html, bool usaCSSPDF = false, string titulo = "Boleto.Net")
+        {
+            html.Append("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n");
+            html.Append("<html xmlns=\"http://www.w3.org/1999/xhtml\">\n");
+            html.Append("<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n");
+            html.Append("<meta charset=\"utf-8\"/>\n");
+            html.Append("<head>");
+            html.Append("    <title>" + titulo + "</title>\n");
+
+            #region Css
+            {
+                string arquivoCSS = usaCSSPDF ? "BoletoNet.BoletoImpressao.BoletoNetPDF.css" : "BoletoNet.BoletoImpressao.BoletoNet.css";
+                Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(arquivoCSS);
+
+                using (StreamReader sr = new StreamReader(stream))
+                {
+                    html.Append("<style>\n");
+                    html.Append(sr.ReadToEnd());
+                    html.Append("</style>\n");
+                    sr.Close();
+                    sr.Dispose();
+                }
+            }
+            #endregion Css
+
+            html.Append("     </head>\n");
+            html.Append("<body>\n");
+        }
+
+        /// <summary>
+        /// Adicionar o SAC da Caixa no rodapé do boleto
+        /// </summary>
+        /// <param name="saida"></param>
+        protected static void AddRodapeSacCaixa(StringBuilder saida)
+        {
+            saida.Append("SAC CAIXA: 0800 726 0101 (Informações, reclamações, sugestões e elogios) <p> Para pessoas com deficiência auditiva ou de fala: 0800 726 2492 <p> Ouvidoria: 0800 725 7474 <p> caixa.gov.br");
+        }
+
+        /// <summary>
+        /// Monta o Footer de um email com pelo menos um boleto dentro.
+        /// </summary>
+        /// <param name="saida">StringBuilder onde o conteudo sera salvo.</param>
+        protected static void HtmlOfflineFooter(StringBuilder saida)
+        {
+            saida.Append("</body>\n");
+            saida.Append("</html>\n");
+        }
+
+
+        /// <summary>
+        /// Junta varios boletos em uma unica AlternateView, para todos serem mandados juntos no mesmo email
+        /// </summary>
+        /// <param name="arrayDeBoletos">Array contendo os boletos a serem mesclados</param>
+        /// <returns></returns>
+        public static AlternateView GeraHtmlDeVariosBoletosParaEmail(BoletoBancario[] arrayDeBoletos)
+        {
+            return GeraHtmlDeVariosBoletosParaEmail(null, arrayDeBoletos);
+        }
+
+        /// <summary>
+        /// Junta varios boletos em uma unica AlternateView, para todos serem mandados juntos no mesmo email
+        /// </summary>
+        /// <param name="textoNoComecoDoEmail">Texto em HTML a ser adicionado no comeco do email</param>
+        /// <param name="arrayDeBoletos">Array contendo os boletos a serem mesclados</param>
+        /// <returns>AlternateView com os dados de todos os boleto.</returns>
+        public static AlternateView GeraHtmlDeVariosBoletosParaEmail(string textoNoComecoDoEmail, BoletoBancario[] arrayDeBoletos)
+        {
+            var corpoDoEmail = new StringBuilder();
+
+            var linkedResources = new List<LinkedResource>();
+            HtmlOfflineHeader(corpoDoEmail);
+            if (textoNoComecoDoEmail != null && textoNoComecoDoEmail != "")
+            {
+                corpoDoEmail.Append(textoNoComecoDoEmail);
+            }
+            foreach (var umBoleto in arrayDeBoletos)
+            {
+                if (umBoleto != null)
+                {
+                    LinkedResource lrImagemLogo;
+                    LinkedResource lrImagemBarra;
+                    LinkedResource lrImagemCodigoBarra;
+                    umBoleto.GeraGraficosParaEmailOffLine(out lrImagemLogo, out lrImagemBarra, out lrImagemCodigoBarra);
+                    var theOutput = umBoleto.MontaHtml(
+                        "cid:" + lrImagemLogo.ContentId,
+                        "cid:" + lrImagemBarra.ContentId,
+                        "<img src=\"cid:" + lrImagemCodigoBarra.ContentId + "\" alt=\"Código de Barras\" />");
+
+                    corpoDoEmail.Append(theOutput);
+
+                    linkedResources.Add(lrImagemLogo);
+                    linkedResources.Add(lrImagemBarra);
+                    linkedResources.Add(lrImagemCodigoBarra);
+                }
+            }
+            HtmlOfflineFooter(corpoDoEmail);
+
+
+
+            AlternateView av = AlternateView.CreateAlternateViewFromString(corpoDoEmail.ToString(), Encoding.Default, "text/html");
+            foreach (var theResource in linkedResources)
+            {
+                av.LinkedResources.Add(theResource);
+            }
+
+
+
+            return av;
+        }
+
+
+        /// <summary>
+        /// Função utilizada gerar o AlternateView necessário para enviar um boleto bancário por e-mail.
+        /// </summary>
+        /// <returns>AlternateView com os dados do boleto.</returns>
+        public AlternateView HtmlBoletoParaEnvioEmail()
+        {
+            return HtmlBoletoParaEnvioEmail(null);
+        }
+
+
+        /// <summary>
+        /// Função utilizada gerar o AlternateView necessário para enviar um boleto bancário por e-mail.
+        /// </summary>
+        /// <param name="textoNoComecoDoEmail">Texto (em HTML) a ser incluido no começo do Email.</param>
+        /// <returns>AlternateView com os dados do boleto.</returns>
+        public AlternateView HtmlBoletoParaEnvioEmail(string textoNoComecoDoEmail)
+        {
+            LinkedResource lrImagemLogo;
+            LinkedResource lrImagemBarra;
+            LinkedResource lrImagemCodigoBarra;
+
+            GeraGraficosParaEmailOffLine(out lrImagemLogo, out lrImagemBarra, out lrImagemCodigoBarra);
+            StringBuilder html = HtmlOffLine(textoNoComecoDoEmail, "cid:" + lrImagemLogo.ContentId, "cid:" + lrImagemBarra.ContentId, "cid:" + lrImagemCodigoBarra.ContentId);
+
+            AlternateView av = AlternateView.CreateAlternateViewFromString(html.ToString(), Encoding.Default, "text/html");
+
+            av.LinkedResources.Add(lrImagemLogo);
+            av.LinkedResources.Add(lrImagemBarra);
+            av.LinkedResources.Add(lrImagemCodigoBarra);
+            return av;
+        }
+
+        /// <summary>
+        /// Gera as tres imagens necessárias para o Boleto
+        /// </summary>
+        /// <param name="lrImagemLogo">O Logo do Banco</param>
+        /// <param name="lrImagemBarra">A Barra Horizontal</param>
+        /// <param name="lrImagemCodigoBarra">O Código de Barras</param>
+        void GeraGraficosParaEmailOffLine(out LinkedResource lrImagemLogo, out LinkedResource lrImagemBarra, out LinkedResource lrImagemCodigoBarra)
+        {
+            this.OnLoad(EventArgs.Empty);
+
+            var randomSufix = new Random().Next().ToString(); // para podermos colocar no mesmo email varios boletos diferentes
+
+            Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("BoletoNet.Imagens." + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg");
+            lrImagemLogo = new LinkedResource(stream, MediaTypeNames.Image.Jpeg);
+            lrImagemLogo.ContentId = "logo" + randomSufix;
+
+
+            MemoryStream ms = new MemoryStream(Utils.ConvertImageToByte(Html.barra));
+            lrImagemBarra = new LinkedResource(ms, MediaTypeNames.Image.Gif);
+            lrImagemBarra.ContentId = "barra" + randomSufix; ;
+
+            C2of5i cb = new C2of5i(Boleto.CodigoBarra.Codigo, 1, 50, Boleto.CodigoBarra.Codigo.Length);
+            ms = new MemoryStream(Utils.ConvertImageToByte(cb.ToBitmap()));
+
+            lrImagemCodigoBarra = new LinkedResource(ms, MediaTypeNames.Image.Gif);
+            lrImagemCodigoBarra.ContentId = "codigobarra" + randomSufix; ;
+
+        }
+
+
+        /// <summary>
+        /// Função utilizada para gravar em um arquivo local o conteúdo do boleto. Este arquivo pode ser aberto em um browser sem que o site esteja no ar.
+        /// </summary>
+        /// <param name="fileName">Path do arquivo que deve conter o código html.</param>
+        public void MontaHtmlNoArquivoLocal(string fileName)
+        {
+            using (FileStream f = new FileStream(fileName, FileMode.Create))
+            {
+                StreamWriter w = new StreamWriter(f, System.Text.Encoding.Default);
+                w.Write(MontaHtml());
+                w.Close();
+                f.Close();
+            }
+        }
+
+        /// <summary>
+        /// Monta o Html do boleto bancário
+        /// </summary>
+        /// <returns>string</returns>
+        public string MontaHtml()
+        {
+            return MontaHtml(null, null);
+        }
+
+
+        /// <summary>
+        /// Monta o Html do boleto bancário
+        /// </summary>
+        /// <param name="fileName">Caminho do arquivo</param>
+        /// <param name="fileName">Caminho do logo do cedente</param>
+        /// <returns>Html do boleto gerado</returns>
+        public string MontaHtml(string fileName, string logoCedente)
+        {
+            if (fileName == null)
+                fileName = System.IO.Path.GetTempPath();
+
+            if (logoCedente != null)
+                vLocalLogoCedente = logoCedente;
+
+            this.OnLoad(EventArgs.Empty);
+
+            string fnLogo = fileName + @"BoletoNet" + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg";
+
+            //if (!System.IO.File.Exists(fnLogo))  Comentado por diego.dariolli pois quando trocava o logo do banco, como já existia no caminho ele não substituia
+            //{
+                Stream streamLogo = Assembly.GetExecutingAssembly().GetManifestResourceStream("BoletoNet.Imagens." + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg");
+                using (Stream file = File.Create(fnLogo))
+                {
+                    CopiarStream(streamLogo, file);
+                }
+            //}
+
+            string fnBarra = fileName + @"BoletoNetBarra.gif";
+            if (!File.Exists(fnBarra))
+            {
+                ImageConverter imgConverter = new ImageConverter();
+                byte[] imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
+                MemoryStream ms = new MemoryStream(imgBuffer);
+
+                using (Stream stream = File.Create(fnBarra))
+                {
+                    CopiarStream(ms, stream);
+                    ms.Flush();
+                    ms.Dispose();
+                }
+            }
+
+            string fnCodigoBarras = System.IO.Path.GetTempFileName();
+            C2of5i cb = new C2of5i(Boleto.CodigoBarra.Codigo, 1, 50, Boleto.CodigoBarra.Codigo.Length);
+            cb.ToBitmap().Save(fnCodigoBarras);
+
+            //return HtmlOffLine(fnCorte, fnLogo, fnBarra, fnPonto, fnBarraInterna, fnCodigoBarras).ToString();
+            return HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras).ToString();
+        }
+
+        /// <summary>
+        /// Monta o Html do boleto bancário para View ASP.Net MVC
+        /// <code>
+        /// <para>Exemplo:</para>
+        /// <para>public ActionResult VisualizarBoleto(string Id)</para>
+        /// <para>{</para>
+        /// <para>    BoletoBancario bb = new BoletoBancario();</para>
+        /// <para>    //...</para>
+        /// <para>    ViewBag.Boleto = bb.MontaHtml("/Content/Boletos/", "teste1");</para>
+        /// <para>    return View();</para>
+        /// <para>}</para>
+        /// <para>//Na view</para>
+        /// <para>@{Layout = null;}@Html.Raw(ViewBag.Boleto)</para>
+        /// </code>
+        /// </summary>
+        /// <param name="Url">Pasta dos boletos. Exemplo MontaHtml("/Content/Boletos/", "000100")</param>
+        /// <param name="fileName">Nome do arquivo para o boleto</param>
+        /// <returns>Html do boleto gerado</returns>
+        /// <desenvolvedor>Sandro Ribeiro</desenvolvedor>
+        /// <criacao>16/11/2012</criacao>
+        public string MontaHtml(string url, string fileName, bool useMapPathSecure = true)
+        {
+            //Variável para o caminho físico do servidor
+            string pathServer = "";
+
+            //Verifica se o usuário informou uma url válida
+            if (url == null)
+            {
+                //Obriga o usuário a especificar uma url válida
+                throw new ArgumentException("Você precisa informar uma pasta padrão.");
+            }
+            else
+            {
+                if (useMapPathSecure)
+                {
+                    //Verifica se o usuário usou barras no início e no final da url
+                    if (url.Substring(url.Length - 1, 1) != "/")
+                        url = url + "/";
+                    if (url.Substring(0, 1) != "/")
+                        url = url + "/";
+                    //Mapeia o caminho físico dos arquivos
+                    pathServer = MapPathSecure(string.Format("~{0}", url));
+                }
+
+                //Verifica se o caminho existe
+                if (!Directory.Exists(pathServer))
+                    throw new ArgumentException("A o caminho físico '{0}' não existe.", pathServer);
+            }
+            //Verifica o nome do arquivo
+            if (fileName == null)
+            {
+                fileName = DateTime.Now.Ticks.ToString();
+            }
+            else
+            {
+                if (fileName == "")
+                    fileName = DateTime.Now.Ticks.ToString();
+            }
+
+            //Mantive o padrão 
+            this.OnLoad(EventArgs.Empty);
+
+            //Prepara o arquivo da logo para ser salvo
+            string fnLogo = pathServer + @"BoletoNet" + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg";
+            //Prepara o arquivo da logo para ser usado no html
+            string fnLogoUrl = url + @"BoletoNet" + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg";
+
+            //Salvo a imagem apenas 1 vez com o código do banco
+            if (!System.IO.File.Exists(fnLogo))
+            {
+                Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("BoletoNet.Imagens." + Utils.FormatCode(_ibanco.Codigo.ToString(), 3) + ".jpg");
+                using (Stream file = File.Create(fnLogo))
+                {
+                    CopiarStream(stream, file);
+                }
+            }
+
+            //Prepara o arquivo da barra para ser salvo
+            string fnBarra = pathServer + @"BoletoNetBarra.gif";
+            //Prepara o arquivo da barra para ser usado no html
+            string fnBarraUrl = url + @"BoletoNetBarra.gif";
+
+            //Salvo a imagem apenas 1 vez
+            if (!File.Exists(fnBarra))
+            {
+                ImageConverter imgConverter = new ImageConverter();
+                byte[] imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
+                MemoryStream ms = new MemoryStream(imgBuffer);
+
+                using (Stream stream = File.Create(fnBarra))
+                {
+                    CopiarStream(ms, stream);
+                    ms.Flush();
+                    ms.Dispose();
+                }
+            }
+
+            //Prepara o arquivo do código de barras para ser salvo
+            string fnCodigoBarras = string.Format("{0}{1}_codigoBarras.jpg", pathServer, fileName);
+            //Prepara o arquivo do código de barras para ser usado no html
+            string fnCodigoBarrasUrl = string.Format("{0}{1}_codigoBarras.jpg", url, fileName);
+
+            C2of5i cb = new C2of5i(Boleto.CodigoBarra.Codigo, 1, 50, Boleto.CodigoBarra.Codigo.Length);
+
+            //Salva o arquivo conforme o fileName
+            cb.ToBitmap().Save(fnCodigoBarras);
+
+            //Retorna o Html para ser usado na view
+            return HtmlOffLine(null, fnLogoUrl, fnBarraUrl, fnCodigoBarrasUrl).ToString();
+        }
+
+        /// <summary>
+        /// Monta o Html do boleto bancário com as imagens embutidas no conteúdo, sem necessidade de links externos
+        /// de acordo com o padrão http://en.wikipedia.org/wiki/Data_URI_scheme
+        /// </summary>
+        /// <param name="convertLinhaDigitavelToImage">Converte a Linha Digitável para imagem, com o objetivo de evitar malwares.</param>
+        /// <param name="somenteHtmlBoleto">Quando true imprime apenas a table do boleto ignorando o CSS e o html/head/body. Utilizado para dimunir o tamanho do html quando imprimir mais de um boleto</param>
+        /// <returns>Html do boleto gerado</returns>
+        /// <desenvolvedor>Iuri André Stona</desenvolvedor>
+        /// <criacao>23/01/2014</criacao>
+        /// <alteracao>08/08/2014</alteracao>
+
+        public string MontaHtmlEmbedded(bool convertLinhaDigitavelToImage = false, bool usaCSSPDF = false, bool imprimeHeader = true, bool imprimeFooter = true)
+        {
+            OnLoad(EventArgs.Empty);
+            Stream streamBarra = null;
+            try
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+
+                string base64Logo = Convert.ToBase64String(ObterLogoDoBanco(CodigoBanco));
+                string fnLogo = string.Format("data:image/gif;base64,{0}", base64Logo);
+
+                streamBarra = assembly.GetManifestResourceStream("BoletoNet.Imagens.barra.gif");
+                string base64Barra = Convert.ToBase64String(new BinaryReader(streamBarra).ReadBytes((int)streamBarra.Length));
+                string fnBarra = string.Format("data:image/gif;base64,{0}", base64Barra);
+
+                var cb = new C2of5i(Boleto.CodigoBarra.Codigo, 1, 50, Boleto.CodigoBarra.Codigo.Length);
+                string base64CodigoBarras = Convert.ToBase64String(cb.ToByte());
+                string fnCodigoBarras = string.Format("data:image/gif;base64,{0}", base64CodigoBarras);
+
+                if (convertLinhaDigitavelToImage)
+                {
+
+                    string linhaDigitavel = Boleto.CodigoBarra.LinhaDigitavel.Replace("  ", " ").Trim();
+
+                    var imagemLinha = Utils.DrawText(linhaDigitavel, new Font("Arial", 30, FontStyle.Bold), Color.Black, Color.White);
+                    string base64Linha = Convert.ToBase64String(Utils.ConvertImageToByte(imagemLinha));
+
+                    string fnLinha = string.Format("data:image/gif;base64,{0}", base64Linha);
+
+                    Boleto.CodigoBarra.LinhaDigitavel = @"<img style=""max-width:420px; margin-bottom: 2px"" src=" + fnLinha + " />";
+                }
+
+                string s = HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras, usaCSSPDF, imprimeHeader, imprimeFooter).ToString();
+
+                if (convertLinhaDigitavelToImage)
+                {
+                    s = s.Replace(".w500", "");
+                }
+
+                return s;
+
+            }
+            finally
+            {
+                if (streamBarra != null)
+                {
+                    streamBarra.Close();
+                }
+            }
+        }
+
+        public byte[] MontaBytesPDF(bool convertLinhaDigitavelToImage = false)
+        {
+            var converter = new NReco.PdfGenerator.HtmlToPdfConverter();
+
+            if (!string.IsNullOrWhiteSpace(TempFilesPath))
+            {
+                converter.TempFilesPath = this.TempFilesPath;
+            }
+
+            if (!string.IsNullOrEmpty(this.PdfToolPath))
+            {
+                converter.PdfToolPath = this.PdfToolPath;
+            }
+            return converter.GeneratePdf(this.MontaHtmlEmbedded(convertLinhaDigitavelToImage, true));
+        }
+
+        /// <summary>
+        /// Lista de Boletos, objetos do tipo
+        /// BoletoBancario
+        /// </summary>
+        /// <param name="boletos">Lista de Boletos, objetos do tipo BoletoBancario</param>
+        /// <param name="tituloNaView">Título Que aparecerá na Aba do Navegador</param>
+        /// <param name="CustomSwitches">Custom WkHtmlToPdf global options</param>
+        /// <param name="tituloPDF">Título No Início do PDF</param>
+        /// <param name="PretoBranco">Preto e Branco = true</param>
+        /// <param name="convertLinhaDigitavelToImage">bool Converter a Linha Digitavel Em Imagem</param>
+        /// <param name="BoletosPorPagina">Quantidade de Boletos até o próximo LineBreak. Lembre de Utilizar o Zoom para ajustar a página</param>
+        /// <param name="ZoomPercent">Percentual da Scala do PDF. Para 3 Boletos na mesma Página com Carnê utilize 80%</param>				
+        /// <returns>byte[], Vetor de bytes do PDF</returns>
+        public byte[] MontaBytesListaBoletosPDF(List<BoletoBancario> boletos, string tituloNaView = "", string CustomSwitches = "", string tituloPDF = "", bool PretoBranco = false, bool convertLinhaDigitavelToImage = false, int BoletosPorPagina = 1, float ZoomPercent = 100)
+        {
+            StringBuilder htmlBoletos = new StringBuilder();
+            HtmlOfflineHeader(htmlBoletos, true, tituloNaView);
+
+            if (!string.IsNullOrEmpty(tituloPDF))
+            {
+                htmlBoletos.Append("<br/><center><h1>");
+                htmlBoletos.Append(tituloPDF);
+                htmlBoletos.Append("</h1></center><br/>");
+            }
+            int qtdeBoletosPagina = 0;
+            foreach (BoletoBancario boleto in boletos)
+            {
+                qtdeBoletosPagina++;
+
+                if (qtdeBoletosPagina % BoletosPorPagina == 0)
+                {
+                    htmlBoletos.Append("<div class='break'>");
+                    qtdeBoletosPagina = 0;
+                }
+                else
+                {
+                    htmlBoletos.Append("<div>");
+                }
+                htmlBoletos.Append(boleto.MontaHtmlEmbedded(convertLinhaDigitavelToImage, true, false, false));
+                htmlBoletos.Append("</div>");
+            }
+            HtmlOfflineFooter(htmlBoletos);
+
+            var converter = new NReco.PdfGenerator.HtmlToPdfConverter()
+            {
+                CustomWkHtmlArgs = CustomSwitches,
+                Grayscale = PretoBranco,
+                Zoom = ZoomPercent / 100
+            };
+            if (!string.IsNullOrEmpty(this.PdfToolPath))
+            {
+                converter.PdfToolPath = this.PdfToolPath;
+            }
+            if (!string.IsNullOrEmpty(this.TempFilesPath))
+            {
+                converter.TempFilesPath = this.TempFilesPath;
+            }
+
+            return converter.GeneratePdf(htmlBoletos.ToString());
+        }
+
+        #endregion Geração do Html OffLine
+
+        public System.Drawing.Image GeraImagemCodigoBarras(Boleto boleto)
+        {
+            C2of5i cb = new C2of5i(boleto.CodigoBarra.Codigo, 1, 50, boleto.CodigoBarra.Codigo.Length);
+            return cb.ToBitmap();
+        }
+
+        /// <summary>
+        /// Obtem o array de bytes da logo do banco.
+        /// </summary>
+        /// <returns>bytes da logo</returns>
+        public static byte[] ObterLogoDoBanco(short codigoBanco)
+        {
+            Stream streamLogo = null;
+            try
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+                streamLogo = assembly.GetManifestResourceStream(string.Format("BoletoNet.Imagens.{0}.jpg", codigoBanco.ToString("000")));
+                return new BinaryReader(streamLogo).ReadBytes((int)streamLogo.Length);
+            }
+            finally
+            {
+                if (streamLogo != null)
+                {
+                    streamLogo.Close();
+                }
+            }
+
+        }
+
+        private void CopiarStream(Stream entrada, Stream saida)
+        {
+            int bytesLidos = 0;
+            byte[] imgBuffer = new byte[entrada.Length];
+
+            while ((bytesLidos = entrada.Read(imgBuffer, 0, imgBuffer.Length)) > 0)
+            {
+                saida.Write(imgBuffer, 0, bytesLidos);
+            }
+        }
+    }
+}

--- a/Html.resx
+++ b/Html.resx
@@ -1,0 +1,817 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="barra" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>imagens\barra.gif;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="barrainterna" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>imagens\barrainterna.gif;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ComprovanteEntrega1" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr&gt;
+						&lt;td class="cpN BT1 Ar"&gt;Comprovante de Entrega&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega2" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="BHead"&gt;
+						&lt;td class="imgLogo Al"&gt;&lt;img src="@URLIMAGEMLOGO" /&gt;&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w65 Ab bc Ac"&gt;@CODIGOBANCO-@DIGITOBANCO&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w500 Ar ld" valign="bottom"&gt;Comprovante de Entrega&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega3" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w298"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w126"&gt;Agência / Código do Cedente&lt;/td&gt;
+						&lt;td class="w106"&gt;Vencimento&lt;/td&gt;
+						&lt;td class="w106"&gt;Nº do Documento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@CEDENTE&lt;/td&gt;
+						&lt;td&gt;@AGENCIACODIGOCEDENTE&lt;/td&gt;
+						&lt;td&gt;@DATAVENCIMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@NUMERODOCUMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega4" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w298"&gt;Pagador&lt;/td&gt;
+						&lt;td class="w126"&gt;Carteira / Nosso Número&lt;/td&gt;
+						&lt;td class="w106"&gt;Espécie&lt;/td&gt;
+						&lt;td class="w106"&gt;Valor do Documento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@SACADO&lt;/td&gt;
+						&lt;td&gt;@NOSSONUMERO&lt;/td&gt;
+						&lt;td&gt;@ESPECIE&lt;/td&gt;
+						&lt;td class="Ar"&gt;@=VALORDOCUMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega5" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w544"&gt;Local de pagamento&lt;/td&gt;
+						&lt;td class="w106"&gt;Data de Processamento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@LOCALPAGAMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@DATAPROCESSAMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega6" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w150"&gt;Recebi(emos) o bloqueto&lt;/td&gt;
+						&lt;td class="w104"&gt;Data&lt;/td&gt;
+						&lt;td class="w164"&gt;Assinatura&lt;/td&gt;
+						&lt;td class="w105"&gt;Data&lt;/td&gt;
+						&lt;td class="w106"&gt;Entregador&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td /&gt;
+						&lt;td /&gt;
+						&lt;td /&gt;
+						&lt;td /&gt;
+						&lt;td&gt;&amp;nbsp;&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega7" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ctN"&gt;
+						&lt;td class="w666 pL6"&gt;Motivo de não entrega (para uso da empresa entregadora)&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr&gt;
+						&lt;td&gt;
+								&lt;table class="cpN w666"&gt;
+										&lt;tr&gt;
+												&lt;td class="w104 pL6"&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Mudou-se&lt;/td&gt;
+												&lt;td class="w104"&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Ausente&lt;/td&gt;
+												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não existe n. indicado&lt;/td&gt;
+												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Recusado&lt;/td&gt;
+												&lt;td class="w104"&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não Procurado&lt;/td&gt;
+										&lt;/tr&gt;
+										&lt;tr&gt;
+												&lt;td class="pL6"&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Desconhecido&lt;/td&gt;
+												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Falecido&lt;/td&gt;
+												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Endereço insuficiente&lt;/td&gt;
+												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Outros (anotar no verso)&lt;/td&gt;
+												&lt;td&gt;&amp;nbsp;&lt;/td&gt;
+										&lt;/tr&gt;
+								&lt;/table&gt;
+						&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="corte" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>imagens\corte.gif;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Instrucoes" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="cpN"&gt;
+						&lt;td class="At Ac"&gt;@TITULO&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="ti"&gt;
+						&lt;td class="At Ac"&gt;@INSTRUCAO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ponto" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>imagens\ponto.gif;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ReciboCedenteParte0" xml:space="preserve">
+    <value>&lt;table class="ctN w666"&gt;
+				&lt;tr&gt;
+						&lt;td class="w666" /&gt;
+				&lt;/tr&gt;
+				&lt;tr&gt;
+						&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr&gt;
+						&lt;td class="cut" /&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;
+		&lt;br /&gt;</value>
+  </data>
+  <data name="ReciboCedenteRelatorioValores" xml:space="preserve">
+    <value>
+			&lt;table class="w666"&gt;
+				&lt;tr class="BHead BT2"&gt;
+						&lt;td class="imgLogo Al"&gt;&lt;img src="@URLIMAGEMLOGO" /&gt;&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w65 Ab bc Ac"&gt;@CODIGOBANCO-@DIGITOBANCO&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w500 Ar ld" valign="bottom"&gt;RECIBO DO SACADO&lt;/td&gt;
+				&lt;/tr&gt;
+			&lt;/table&gt;				
+			&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td&gt;Local de pagamento&lt;/td&gt;
+						&lt;td&gt;&lt;/td&gt;
+				&lt;/tr&gt;						
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@LOCALPAGAMENTO&lt;/td&gt;
+						&lt;td&gt;&lt;/td&gt;						
+				&lt;/tr&gt;						
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w472"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w180"&gt;Agência / Código do Beneficiário&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@CEDENTE&lt;/td&gt;
+						&lt;td class="Ar"&gt;@AGENCIACONTA&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;
+		</value>
+  </data>
+  <data name="CabecalhoTabelaDemonstrativo" xml:space="preserve">
+    <value>
+			&lt;table class="w666"&gt;
+				&lt;tr class="rBb"&gt;
+						&lt;td class="Ac ld" colspan="4"&gt;Demonstrativo&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="ct"&gt;
+					&lt;td class="w62"&gt;&lt;/td&gt;
+					&lt;td class="w62"&gt;&lt;/td&gt;
+					&lt;td class="w62"&gt;&lt;/td&gt;
+					&lt;td class="w62"&gt;&lt;/td&gt;				
+					@ITENSDEMONSTRATIVO
+			&lt;/tr&gt;							
+		&lt;/table class="rBb td"&gt;	
+		&lt;table class="ctN w666"&gt;
+				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
+				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
+		&lt;/table&gt;				
+		</value>
+  </data>
+  <data name="GrupoDemonstrativo" xml:space="preserve">
+    <value>
+				&lt;tr class="ct"&gt;
+					&lt;td class="cp"&gt;@DESCRICAOGRUPO&lt;/td&gt;
+					&lt;td&gt;@DESCRICAOITEM&lt;/td&gt;
+					&lt;td&gt;@REFERENCIAITEM&lt;/td&gt;
+					&lt;td&gt;@VALORITEM&lt;/td&gt;
+				&lt;/tr&gt;
+		</value>
+  </data>
+  <data name="TotalDemonstrativo" xml:space="preserve">
+    <value>
+				&lt;tr class="cp h13 rBb"&gt;
+					&lt;td&gt;Total&lt;/td&gt;
+					&lt;td&gt;&lt;/td&gt;
+					&lt;td&gt;&lt;/td&gt;
+					&lt;td&gt;@VALORTOTALGRUPO&lt;/td&gt;
+				&lt;/tr&gt;
+		</value>
+  </data>
+  <data name="ReciboCedenteParte1" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="BHead"&gt;
+						&lt;td class="imgLogo Al"&gt;&lt;img src="@URLIMAGEMLOGO" /&gt;&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w65 Ab bc Ac"&gt;@CODIGOBANCO-@DIGITOBANCO&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w500 Ar ld" valign="bottom"&gt;@LINHADIGITAVEL&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte10" xml:space="preserve">
+    <value>&lt;table class="w666 ctN"&gt;
+				&lt;tr&gt;
+						&lt;td class="pL6  w409"&gt;Sacador / Avalista: @AVALISTA&lt;/td&gt;
+						&lt;td class="w250 Ar"&gt;Autenticação mecânica - &lt;b class="cpN"&gt;Ficha de Compensação&lt;/b&gt;&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte11" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr&gt;
+						&lt;td class="EcdBar Al pL10"&gt;@IMAGEMCODIGOBARRA&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte12" xml:space="preserve">
+    <value>&lt;table class="ctN w666"&gt;
+				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
+				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte2" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w472"&gt;Local de pagamento&lt;/td&gt;
+						&lt;td class="w180"&gt;Vencimento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@LOCALPAGAMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@DATAVENCIMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte3" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w472"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w180"&gt;Agência / Código do Beneficiário&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@CEDENTE_BOLETO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@AGENCIACONTA&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte4" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w113"&gt;Data do documento&lt;/td&gt;
+						&lt;td class="w163"&gt;N&lt;u&gt;o&lt;/u&gt; documento&lt;/td&gt;
+						&lt;td class="w62"&gt;Espécie doc.&lt;/td&gt;
+						&lt;td class="w34"&gt;Aceite&lt;/td&gt;
+						&lt;td class="w72"&gt;Data processamento&lt;/td&gt;
+						&lt;td class="w180"&gt;Carteira / Nosso número&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@DATADOCUMENTO&lt;/td&gt;
+						&lt;td&gt;@NUMERODOCUMENTO&lt;/td&gt;
+						&lt;td&gt;@ESPECIEDOCUMENTO&lt;/td&gt;
+						&lt;td&gt;@ACEITE&lt;/td&gt;
+						&lt;td&gt;@DATAPROCESSAMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@NOSSONUMERO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte5" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w113"&gt;Uso do banco&lt;/td&gt;
+						&lt;td class="w83"&gt;Carteira&lt;/td&gt;
+						&lt;td class="w53"&gt;Espécie&lt;/td&gt;
+						&lt;td class="w123"&gt;Quantidade&lt;/td&gt;
+						&lt;td class="w72"&gt;(x) Valor&lt;/td&gt;
+						&lt;td class="w180"&gt;(=) Valor documento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@USODOBANCO&lt;/td&gt;
+						&lt;td class="Al"&gt;@CARTEIRA&lt;/td&gt;
+						&lt;td class="Al"&gt;@ESPECIE&lt;/td&gt;
+						&lt;td&gt;@QUANTIDADE&lt;/td&gt;
+						&lt;td&gt;@VALORDOCUMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@=VALORDOCUMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte6" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="rc6"&gt;
+						&lt;td class="w478"&gt;
+								&lt;div class="ctN pL10"&gt;Instruções (Texto de responsabilidade do beneficiário)&lt;/div&gt;
+                &lt;div class="cpN pL10 it" style="height:105px; overflow:hidden"&gt;@INSTRUCOES&lt;/div&gt;                
+						&lt;/td&gt;
+						&lt;td class="w186"&gt;
+								&lt;div class="t"&gt;(-) Desconto / Abatimentos&lt;/div&gt;
+								&lt;div class="c BB"&gt;@DESCONTOS&lt;/div&gt;
+								&lt;div class="t"&gt;(-) Outras deduções&lt;/div&gt;
+								&lt;div class="c BB"&gt;@OUTRASDEDUCOES&lt;/div&gt;
+								&lt;div class="t"&gt;(+) Mora / Multa&lt;/div&gt;
+								&lt;div class="c BB"&gt;@MORAMULTA&lt;/div&gt;
+								&lt;div class="t"&gt;(+) Outros acréscimos&lt;/div&gt;
+								&lt;div class="c BB"&gt;@OUTROSACRESCIMOS&lt;/div&gt;
+								&lt;div class="t"&gt;(=) Valor cobrado&lt;/div&gt;
+								&lt;div class="c"&gt;@VALORCOBRADO&lt;/div&gt;
+						&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte7" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ReciboCedenteParte8" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w659"&gt;Pagador&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12"&gt;
+						&lt;td class="At"&gt;@SACADO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte9" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="rBb"&gt;
+						&lt;td class="w478 BL"&gt;
+								&lt;div class="cpN pL6"&gt;@INFOSACADO&lt;/div&gt;
+						&lt;/td&gt;
+						&lt;td class="Ab BL"&gt;
+								&lt;div class="ctN pL6"&gt;Cód. baixa&lt;/div&gt;
+						&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte1" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr&gt;
+						&lt;td class="ctN cut" /&gt;
+				&lt;/tr&gt;
+				&lt;tr&gt;
+						&lt;td class="cpN Ar"&gt;Recibo do Pagador&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte2" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="BHead"&gt;
+						&lt;td class="imgLogo Al"&gt;&lt;img src="@URLIMGCEDENTE" /&gt;&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w65 Ab bc Ac"&gt;@CODIGOBANCO-@DIGITOBANCO&lt;/td&gt;
+						&lt;td class="barra"&gt;&lt;img src="@URLIMAGEMBARRA" /&gt;&lt;/td&gt;
+						&lt;td class="w500 Ar Ab ld"&gt;@LINHADIGITAVEL&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte3" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13 At"&gt;
+						&lt;td class="w298"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w126"&gt;Agência / Código do Beneficiário&lt;/td&gt;
+						&lt;td class="w34"&gt;Espécie&lt;/td&gt;
+						&lt;td class="w45"&gt;Quantidade&lt;/td&gt;
+						&lt;td class="w128"&gt;Carteira / Nosso número&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 At rBb"&gt;
+						&lt;td&gt;@CEDENTE&lt;/td&gt;
+						&lt;td&gt;@AGENCIACODIGOCEDENTE&lt;/td&gt;
+						&lt;td&gt;@ESPECIE&lt;/td&gt;
+						&lt;td&gt;@QUANTIDADE&lt;/td&gt;
+						&lt;td class="Ar"&gt;@NOSSONUMERO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte4" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w192"&gt;Número do documento&lt;/td&gt;
+						&lt;td class="w132"&gt;CPF/CNPJ&lt;/td&gt;
+						&lt;td class="w134"&gt;Vencimento&lt;/td&gt;
+						&lt;td class="w180"&gt;Valor documento&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@NUMERODOCUMENTO&lt;/td&gt;
+						&lt;td&gt;@CPFCNPJ&lt;/td&gt;
+						&lt;td&gt;@DATAVENCIMENTO&lt;/td&gt;
+						&lt;td class="Ar"&gt;@=VALORDOCUMENTO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte5" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w113"&gt;(-) Desconto / Abatimentos&lt;/td&gt;
+						&lt;td class="w112"&gt;(-) Outras deduções&lt;/td&gt;
+						&lt;td class="w113"&gt;(+) Mora / Multa&lt;/td&gt;
+						&lt;td class="w113"&gt;(+) Outros acréscimos&lt;/td&gt;
+						&lt;td class="w180"&gt;(=) Valor cobrado&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb Ab"&gt;
+						&lt;td&gt;@DESCONTOS&lt;/td&gt;
+						&lt;td&gt;@OUTRASDEDUCOES&lt;/td&gt;
+						&lt;td&gt;@MORAMULTA&lt;/td&gt;
+						&lt;td&gt;@OUTROSACRESCIMOS&lt;/td&gt;
+						&lt;td class="Ar"&gt;&amp;nbsp;@VALORCOBRADO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte6" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w659"&gt;Pagador&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12"&gt;
+						&lt;td&gt;@SACADO&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td&gt;@INFOSACADO&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte7" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ctN h13"&gt;
+						&lt;td class="pL6"&gt;Instruções&lt;/td&gt;
+						&lt;td class="w180 Ar"&gt;Autenticação mecânica&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cpN h12"&gt;
+						&lt;td class="pL6 it"&gt;@INSTRUCOES&lt;/td&gt;
+						&lt;td class="pL6 Ar"&gt;@AUTENTICACAOMECANICA&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte8" xml:space="preserve">
+    <value>&lt;table class="ctN w666"&gt;
+				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
+				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
+				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ComprovanteEntrega71" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+	 &lt;tr class="ctN"&gt;
+			&lt;td class="w666 pL6"&gt;Observações (para uso da empresa entregadora)&lt;/td&gt;
+	 &lt;/tr&gt;
+	 &lt;tr&gt;
+			&lt;td&gt;
+				 &lt;table class="cpN w666"&gt;
+						&lt;tr&gt;
+							 &lt;td class="w104 pL6"&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td class="w104"&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td class="w104"&gt;&amp;nbsp;&lt;/td&gt;
+						&lt;/tr&gt;
+						&lt;tr&gt;
+							 &lt;td class="pL6"&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+						&lt;/tr&gt;
+				 &lt;/table&gt;
+			&lt;/td&gt;
+	 &lt;/tr&gt;
+&lt;/table&gt;</value>
+  </data>
+  <data name="Carne" xml:space="preserve">
+    <value>&lt;table cellpadding="0" cellspacing="0"&gt;
+						&lt;tr&gt;
+								&lt;td valign="top"&gt;
+										&lt;table class="150"&gt;
+												&lt;tr class="BHead"&gt;
+														&lt;td class="imgLogo Al"&gt;
+															&lt;img src="@URLIMAGEMLOGO" /&gt;
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13 At"&gt;
+														&lt;td class="w298"&gt;
+																Beneficiário
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 At rBb"&gt;
+														&lt;td&gt;
+																@CEDENTE
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;										
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w192"&gt;
+																Parcela/Total
+														&lt;/td&gt;
+														&lt;td class="w192"&gt;
+																Vencimento
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb"&gt;
+														&lt;td&gt;
+																@PARCELATOTAL
+														&lt;/td&gt;
+														&lt;td&gt;
+																@DATAVENCIMENTO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w192"&gt;
+																Agência/Código do Cendente
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb"&gt;
+														&lt;td&gt;
+																@AGENCIACODIGOCEDENTE
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(=) Valor do Documento
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@=VALORDOCUMENTO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(-) Desconto / Abatimentos
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@DESCONTOS
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(-) Outras deduções
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@OUTRASDEDUCOES
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(+) Mora / Multa
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@MORAMULTA
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(+) Outros acréscimos
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@OUTROSACRESCIMOS
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																(=) Valor Cobrado
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td&gt;
+																@VALORCOBRADO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13 At"&gt;
+														&lt;td class="w298"&gt;
+																Nosso Número
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 At rBb"&gt;
+														&lt;td&gt;
+																@NOSSONUMERO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w192"&gt;
+																Número do documento
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb"&gt;
+														&lt;td&gt;
+																@NUMERODOCUMENTO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;										
+										&lt;table class="w150"&gt;
+												&lt;tr class="ct h13"&gt;
+														&lt;td class="w113"&gt;
+																Pagador
+														&lt;/td&gt;
+												&lt;/tr&gt;
+												&lt;tr class="cp h12 rBb Ab"&gt;
+														&lt;td class="pb4"&gt;
+																@SACADO
+														&lt;/td&gt;
+												&lt;/tr&gt;
+										&lt;/table&gt;
+								&lt;/td&gt;
+								&lt;td&gt;
+										&lt;div class="ebc" /&gt;
+								&lt;/td&gt;
+								&lt;td&gt;
+										#BOLETO#
+								&lt;/td&gt;
+						&lt;/tr&gt;
+				&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte10" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w659"&gt;Beneficiário Endereço / Sacador Avalista: @AVALISTA&lt;/td&gt; 
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td class="At"&gt;@ENDERECOCEDENTE&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboCedenteParte13" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+        &lt;tr class="ct h13"&gt;
+            &lt;td class="w472"&gt;Beneficiário&lt;/td&gt;
+            &lt;td class="w180"&gt;Agência / Código Beneficiário&lt;/td&gt;
+        &lt;/tr&gt;
+        &lt;tr class="cp h12 rBb"&gt;
+            &lt;td&gt;@DADOSCEDENTE&lt;/td&gt;
+            &lt;td class="Ar"&gt;@AGENCIACONTA&lt;/td&gt;
+        &lt;/tr&gt;
+    &lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte10SemSacador" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
+				&lt;tr class="ct h13"&gt;
+						&lt;td class="w659"&gt;Beneficiário Endereço&lt;/td&gt; 
+				&lt;/tr&gt;
+				&lt;tr class="cp h12 rBb"&gt;
+						&lt;td class="At"&gt;@ENDERECOCEDENTE&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+</root>


### PR DESCRIPTION
Peguei um homologador no Banrisul que está implicando com o label no recibo onde diz "Endereço cedente / Avalista"
Ele não entende que são dois campos e por isso pediu para retirar a palavra "Avalista"

Esse PR cria opção de layout somente com "endereço do cedente"